### PR TITLE
删除"快捷键附加AE"的说明

### DIFF
--- a/附件包/Kratos食用说明书.ini
+++ b/附件包/Kratos食用说明书.ini
@@ -1723,32 +1723,6 @@ UploadX.NotAffectMarks=none ;不影响带有这些标记的对象
 UploadX.OnlyAffectMarks=none ;只影响带有这些标记的对象
 
 
-; 通过快捷键为选中的单位附加AE，可以设置多组，X=[0-127]，不写等同于0
-[CombatDamage]
-[TechnoType]
-HotKeyX.AttachEffects=AutoWeapon1,StandTest1
-HotKeyX.AttachChances=100%,100% ;附加效果的成功率
-HotKeyX.Keys=0 ;响应哪个按键，0\1\2\3\4，分别对应快捷键1234，0表示全部
-; 对象影响过滤器专属设置
-HotKeyX.AffectTypes=none ;类型过滤，可影响的单位，如果设置，则只可以影响列表中的单位
-HotKeyX.NotAffectTypes=none ;类型过滤，不可影响的单位，如果设置，则不影响列表中的单位，优先级更高
-; 对象影响单位设置
-HotKeyX.AffectBuilding=yes ;类型过滤，影响建筑
-HotKeyX.AffectInfantry=yes ;类型过滤，影响步兵
-HotKeyX.AffectUnit=yes ;类型过滤，影响载具
-HotKeyX.AffectAircraft=yes ;类型过滤，影响飞机
-; 影响特定对象
-HotKeyX.AffectStand=no ;影响替身
-HotKeyX.AffectInAir=yes ;影响在空中的单位
-HotKeyX.NotAffectMarks=none ;不影响带有这些标记的对象
-HotKeyX.OnlyAffectMarks=none ;只影响带有这些标记的对象
-; 对象敌我识别专属设置
-HotKeyX.AffectsOwner=yes ;是否影响同阵营的
-HotKeyX.AffectsAllies=no ;是否影响友军
-HotKeyX.AffectsEnemies=no ;是否影响敌人
-HotKeyX.AffectsCivilian=no ;是否影响中立目标
-
-
 ; 通过发射武器为自身附加AE，可以设置多组，X=[0-127]，不写等同于0，在载具内发射时不会附加
 ; 对AttachFire同样有效，作用于AttachFire时的目标是射手而不是武器持有者
 ; 当AttachFire的武器是从抛射体上射出时，附加的对象是抛射体而非抛射体的持有人


### PR DESCRIPTION
根据Kratos作者双杀步枪的说法，"快捷键附加AE"在KratosPP里已经被移除了，所以我将无用的说明删了