### PR TITLE
更改"关闭空袭的激光笔、染色、闪烁等"的说明

### DIFF
--- a/附件包/Kratos食用说明书.ini
+++ b/附件包/Kratos食用说明书.ini
@@ -642,7 +642,7 @@ WeaponTurretCustomSHPX=fvtur1.shp ;IFVModeX+1的炮塔自定义shp图像的文�
 
 
 ; 关闭空袭的激光笔、染色、闪烁等，严禁空袭步兵，WWSB极大概率崩溃
-[BORIS]
+[TechnoType]
 AirstrikeTargetLaser=-1 ;自定义照射的颜色，对应[ColorAdd]的序号
 AirstrikeTargetLaserColor=252,0,0 ;自定义照射的颜色，RGB888
 AirstrikeDisableLine=no ;关闭空袭的激光指示


### PR DESCRIPTION
实际上这玩意载具飞机建筑也能用，所以我把[BORIS]改成了[TechnoType]