### PR TITLE
GetEffects: 弹头/Broadcast/Stack 语法糖

### DIFF
--- a/src/Ext/EffectType/AttachEffectTypeData.h
+++ b/src/Ext/EffectType/AttachEffectTypeData.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include <string>
 #include <vector>
@@ -12,6 +12,9 @@ public:
 	std::vector<double> AttachEffectChances{}; // 附加成功率，应该只对弹头有用
 
 	bool AttachToSource = false; // 用弹头附加时，反过来附加给攻击者
+
+	std::vector<std::string> GetEffectTypes{};
+	std::vector<double> GetEffectChances{};
 
 	bool AttachFullAirspace = false; // 搜索圆柱体范围
 
@@ -29,13 +32,16 @@ public:
 
 		AttachToSource = reader->Get("AttachToSource", AttachToSource);
 
+		GetEffectTypes = reader->GetList("GetEffectTypes", GetEffectTypes);
+		GetEffectChances = reader->GetChanceList("GetEffectChances", GetEffectChances);
+
 		AttachFullAirspace = reader->Get("AttachFullAirspace", AttachFullAirspace);
 
 		StandTrainCabinLength = reader->Get("StandTrainCabinLength", StandTrainCabinLength);
 		// 由乘客读取
 		AEMode = reader->Get("AEMode", AEMode);
 
-		Enable = !AttachEffectTypes.empty();
+		Enable = !AttachEffectTypes.empty() || !GetEffectTypes.empty();
 	}
 
 	// 通过AEMode触发附加的多组AE的设置读取

--- a/src/Ext/EffectType/Effect/BroadcastData.h
+++ b/src/Ext/EffectType/Effect/BroadcastData.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include <string>
 #include <vector>
@@ -18,6 +18,8 @@ public:
 
 	std::vector<std::string> Types{};
 	std::vector<double> AttachChances{};
+	std::vector<std::string> GetTypes{};
+	std::vector<double> GetChances{};
 	int Rate = 15;
 	float RangeMin = 0;
 	float RangeMax = -1;
@@ -27,13 +29,15 @@ public:
 	{
 		Types = reader->GetList(title + "Types", Types);
 		AttachChances = reader->GetChanceList(title + "AttachChances", AttachChances);
+		GetTypes = reader->GetList(title + "GetTypes", GetTypes);
+		GetChances = reader->GetChanceList(title + "GetChances", GetChances);
 		Rate = reader->Get(title + "Rate", Rate);
 		RangeMin = reader->Get(title + "RangeMin", RangeMin);
 		RangeMax = reader->Get(title + "RangeMax", RangeMax);
 		FullAirspace = reader->Get(title + "FullAirspace", FullAirspace);
 
 		// 0 时关闭，-1全地图
-		Enable = !Types.empty() && RangeMax != 0;
+		Enable = (!Types.empty() || !GetTypes.empty()) && RangeMax != 0;
 	}
 
 #pragma region save/load
@@ -44,6 +48,8 @@ public:
 			.Process(this->Enable)
 			.Process(this->Types)
 			.Process(this->AttachChances)
+			.Process(this->GetTypes)
+			.Process(this->GetChances)
 			.Process(this->Rate)
 			.Process(this->RangeMin)
 			.Process(this->RangeMax)

--- a/src/Ext/EffectType/Effect/BroadcastEffect.cpp
+++ b/src/Ext/EffectType/Effect/BroadcastEffect.cpp
@@ -1,12 +1,16 @@
-﻿#include "BroadcastEffect.h"
+#include "BroadcastEffect.h"
 
 #include <Ext/Helper/Finder.h>
 #include <Ext/Helper/FLH.h>
 #include <Ext/Helper/Scripts.h>
 #include <Ext/Helper/Status.h>
 
-void BroadcastEffect::FindAndAttach(BroadcastEntity data, HouseClass* pHouse)
+void BroadcastEffect::FindAndAttach(BroadcastEntity data, std::vector<std::string>& types, std::vector<double>& chances, HouseClass* pHouse, bool getMode)
 {
+	if (types.empty())
+	{
+		return;
+	}
 	CoordStruct location = pObject->GetCoords();
 	ObjectClass* pSource = AE->pSource;
 	HouseClass* pSourceHouse = AE->pSourceHouse;
@@ -16,12 +20,17 @@ void BroadcastEffect::FindAndAttach(BroadcastEntity data, HouseClass* pHouse)
 		pSource = pObject;
 		pSourceHouse = pHouse;
 	}
-	// 广播持有者是抛射体：来源改为发射者（满足 pSource 必须是 TechnoClass 约束），坐标另传
 	if (pBullet)
 	{
 		pSource = pBullet->Owner;
 		pSourceHouse = pHouse;
 		projectileLocation = pObject->GetCoords();
+	}
+	// Get模式：范围内单位给广播塔（self）贴AE
+	AttachEffect* selfAEM = nullptr;
+	if (getMode)
+	{
+		selfAEM = AE->AEManager;
 	}
 	// 搜索单位
 	if (Data->AffectTechno)
@@ -29,8 +38,14 @@ void BroadcastEffect::FindAndAttach(BroadcastEntity data, HouseClass* pHouse)
 		int attachCount = 0;
 		FindTechnoOnMark([&](TechnoClass* pTarget, AttachEffect* aeManager)
 			{
-				// 赋予AE
-				aeManager->Attach(data.Types, data.AttachChances, false, pSource, pSourceHouse, projectileLocation);
+				if (getMode)
+				{
+					selfAEM->Attach(types, chances, false, pTarget, pTarget->Owner, projectileLocation);
+				}
+				else
+				{
+					aeManager->Attach(types, chances, false, pSource, pSourceHouse, projectileLocation);
+				}
 				attachCount++;
 				if (Data->MaxAttachTechno > 0 && attachCount >= Data->MaxAttachTechno)
 				{
@@ -45,8 +60,15 @@ void BroadcastEffect::FindAndAttach(BroadcastEntity data, HouseClass* pHouse)
 		int attachCount = 0;
 		FindBulletOnMark([&](BulletClass* pTarget, AttachEffect* aeManager)
 			{
-				// 赋予AE
-				aeManager->Attach(data.Types, data.AttachChances, false, pSource, pSourceHouse, projectileLocation);
+				if (getMode)
+				{
+					HouseClass* pTargetHouse = GetSourceHouse(pTarget);
+					selfAEM->Attach(types, chances, false, pTarget, pTargetHouse, projectileLocation);
+				}
+				else
+				{
+					aeManager->Attach(types, chances, false, pSource, pSourceHouse, projectileLocation);
+				}
 				attachCount++;
 				if (Data->MaxAttachBullet > 0 && attachCount >= Data->MaxAttachBullet)
 				{
@@ -102,7 +124,8 @@ void BroadcastEffect::OnUpdate()
 					AE->TimeToDie();
 				}
 				_delayTimer.Start(data.Rate);
-				FindAndAttach(data, pHouse);
+				FindAndAttach(data, data.Types, data.AttachChances, pHouse);
+				FindAndAttach(data, data.GetTypes, data.GetChances, pHouse, true);
 			}
 		}
 	}

--- a/src/Ext/EffectType/Effect/BroadcastEffect.h
+++ b/src/Ext/EffectType/Effect/BroadcastEffect.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include <string>
 #include <vector>
@@ -56,7 +56,7 @@ public:
 	}
 #pragma endregion
 private:
-	void FindAndAttach(BroadcastEntity data, HouseClass* pHouse);
+	void FindAndAttach(BroadcastEntity data, std::vector<std::string>& types, std::vector<double>& chances, HouseClass* pHouse, bool getMode = false);
 
 	int _count = 0;
 	CDTimerClass _delayTimer{};

--- a/src/Ext/EffectType/Effect/StackData.h
+++ b/src/Ext/EffectType/Effect/StackData.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include <string>
 #include <vector>
@@ -90,12 +90,17 @@ public:
 	std::vector<double> AttachChances{};
 	bool AttachToSource = false;
 
+	std::vector<std::string> SourceGetEffects{};
+	std::vector<double> SourceGetEffectChances{};
+
 	bool Remove = false;
 	std::vector<std::string> RemoveEffects{};
 	std::vector<int> RemoveEffectsLevel{};
 	std::vector<std::string> RemoveEffectsWithMarks{};
 	bool RemoveEffectsSkipNext = false;
 	bool RemoveToSource = false;
+
+	std::vector<std::string> SourceRemoveEffects{};
 
 	std::vector<int> RemoveLevel{};
 	bool RemoveAll = true;
@@ -124,6 +129,10 @@ public:
 		Attach = !AttachEffects.empty();
 		AttachToSource = reader->Get(title + "AttachToSource", AttachToSource);
 
+		SourceGetEffects = reader->GetList(title + "SourceGetEffects", SourceGetEffects);
+		ClearIfGetNone(SourceGetEffects);
+		SourceGetEffectChances = reader->GetChanceList(title + "SourceGetEffectChances", SourceGetEffectChances);
+
 		RemoveEffects = reader->GetList(title + "RemoveEffects", RemoveEffects);
 		ClearIfGetNone(RemoveEffects);
 		RemoveEffectsLevel = reader->GetList(title + "RemoveEffectsLevel", RemoveEffectsLevel);
@@ -133,11 +142,14 @@ public:
 		RemoveEffectsSkipNext = reader->Get(title + "RemoveEffectsSkipNext", RemoveEffectsSkipNext);
 		RemoveToSource = reader->Get(title + "RemoveToSource", RemoveToSource);
 
+		SourceRemoveEffects = reader->GetList(title + "SourceRemoveEffects", SourceRemoveEffects);
+		ClearIfGetNone(SourceRemoveEffects);
+
 		RemoveLevel = reader->GetList(title + "RemoveLevel", RemoveLevel);
 		RemoveAll = reader->Get(title + "RemoveAll", RemoveAll);
 		RemoveSkipNext = reader->Get(title + "RemoveSkipNext", RemoveSkipNext);
 
-		Enable = (!Watch.empty() || WatchMission != Mission::None) && (Attach || Remove);
+		Enable = (!Watch.empty() || WatchMission != Mission::None) && (Attach || Remove || !SourceGetEffects.empty() || !SourceRemoveEffects.empty());
 	}
 
 #pragma region save/load
@@ -155,6 +167,8 @@ public:
 			.Process(this->AttachEffects)
 			.Process(this->AttachChances)
 			.Process(this->AttachToSource)
+			.Process(this->SourceGetEffects)
+			.Process(this->SourceGetEffectChances)
 
 			.Process(this->Remove)
 			.Process(this->RemoveEffects)
@@ -162,6 +176,7 @@ public:
 			.Process(this->RemoveEffectsWithMarks)
 			.Process(this->RemoveEffectsSkipNext)
 			.Process(this->RemoveToSource)
+			.Process(this->SourceRemoveEffects)
 
 			.Process(this->RemoveLevel)
 			.Process(this->RemoveAll)

--- a/src/Ext/EffectType/Effect/StackEffect.cpp
+++ b/src/Ext/EffectType/Effect/StackEffect.cpp
@@ -1,4 +1,4 @@
-﻿#include "StackEffect.h"
+#include "StackEffect.h"
 
 #include <Ext/Helper/Finder.h>
 #include <Ext/Helper/FLH.h>
@@ -162,6 +162,36 @@ void StackEffect::Watch()
 				{
 					aeManager->DetachByMarks(Data->RemoveEffectsWithMarks, Data->RemoveEffectsSkipNext);
 				}
+			}
+		}
+		// SourceGetEffects: 始终向来源附着AE
+		if (!Data->SourceGetEffects.empty())
+		{
+			AttachEffect* aeManager = GetAEManager<TechnoExt>(AE->pSource);
+			TechnoClass* pSource = nullptr;
+			HouseClass* pSourceHouse = nullptr;
+			if (pTechno)
+			{
+				pSource = pTechno;
+				pSourceHouse = pTechno->Owner;
+			}
+			else if (pBullet)
+			{
+				pSource = pBullet->Owner;
+				pSourceHouse = GetHouse(pBullet);
+			}
+			if (aeManager && pSource)
+			{
+				aeManager->Attach(Data->SourceGetEffects, Data->SourceGetEffectChances, false, pSource, pSourceHouse);
+			}
+		}
+		// SourceRemoveEffects: 始终从来源移除AE
+		if (!Data->SourceRemoveEffects.empty())
+		{
+			AttachEffect* aeManager = GetAEManager<TechnoExt>(AE->pSource);
+			if (aeManager)
+			{
+				aeManager->DetachByName(Data->SourceRemoveEffects, false);
 			}
 		}
 		// 移除被监视者

--- a/src/Ext/Helper/Finder.cpp
+++ b/src/Ext/Helper/Finder.cpp
@@ -1,4 +1,4 @@
-﻿#include "Finder.h"
+#include "Finder.h"
 
 #include <iterator>
 #include <algorithm>
@@ -343,8 +343,13 @@ void FindAndAttachEffect(CoordStruct location, int damage, WarheadTypeClass* pWH
 	if (aeTypeData->Enable)
 	{
 		bool attachToSource = aeTypeData->AttachToSource;
+		bool hasGetEffects = !aeTypeData->GetEffectTypes.empty();
 		AttachEffect* sourceAEM = nullptr;
-		if (attachToSource && !TryGetAEManager<TechnoExt>(abstract_cast<TechnoClass*>(pAttacker), sourceAEM))
+		if (attachToSource || hasGetEffects)
+		{
+			TryGetAEManager<TechnoExt>(abstract_cast<TechnoClass*>(pAttacker), sourceAEM);
+		}
+		if (attachToSource && !sourceAEM)
 		{
 			return;
 		}
@@ -354,6 +359,12 @@ void FindAndAttachEffect(CoordStruct location, int damage, WarheadTypeClass* pWH
 		bool findBullet = false;
 		// 快速检索是否需要查找单位或者抛射体清单
 		for (std::string ae : aeTypeData->AttachEffectTypes)
+		{
+			AttachEffectData* aeData = INI::GetConfig<AttachEffectData>(INI::Rules, ae.c_str())->Data;
+			findTechno |= aeData->AffectTechno;
+			findBullet |= aeData->AffectBullet;
+		}
+		for (std::string ae : aeTypeData->GetEffectTypes)
 		{
 			AttachEffectData* aeData = INI::GetConfig<AttachEffectData>(INI::Rules, ae.c_str())->Data;
 			findTechno |= aeData->AffectTechno;
@@ -434,6 +445,10 @@ void FindAndAttachEffect(CoordStruct location, int damage, WarheadTypeClass* pWH
 							attachCount++;
 						}
 					}
+					if (hasGetEffects && sourceAEM)
+					{
+						sourceAEM->Attach(aeTypeData->GetEffectTypes, aeTypeData->GetEffectChances, false, pTarget, pTargetHouse, location);
+					}
 				}
 				// 附加次数上限
 				if (warheadTypeData->MaxAttachTechno > 0 && attachCount >= warheadTypeData->MaxAttachTechno)
@@ -470,6 +485,10 @@ void FindAndAttachEffect(CoordStruct location, int damage, WarheadTypeClass* pWH
 								attachCount++;
 							}
 						}
+						if (hasGetEffects && sourceAEM)
+						{
+							sourceAEM->Attach(aeTypeData->GetEffectTypes, aeTypeData->GetEffectChances, false, pTarget, pTargetSourceHouse, location);
+						}
 						// 附加次数上限
 						if (warheadTypeData->MaxAttachBullet > 0 && attachCount >= warheadTypeData->MaxAttachBullet)
 						{
@@ -478,7 +497,7 @@ void FindAndAttachEffect(CoordStruct location, int damage, WarheadTypeClass* pWH
 					}
 				}
 				return false;
-				}, location, pWH->CellSpread, 0, fullAirspace);
+					}, location, pWH->CellSpread, 0, fullAirspace);
 		}
 	}
 }


### PR DESCRIPTION
弹头GetEffectTypes: 始终向攻击者附着AE，复用AttachEffectTypes+AttachToSource同套过滤

Broadcast.GetTypes: 范围内单位给广播塔贴AE，复用FindAndAttach反向pSource

Stack.SourceGetEffects/SourceRemoveEffects: 向来源附着/移除另一套AE列表

用来独立反向贴AE的另一套小标签，这下再也不需要插个Stack反向器了