### PR TITLE
AutoWeapon: LaunchFromProjectile标签，仅显式开启时从弹着点发射

### DIFF
--- a/src/Ext/EffectType/Effect/AutoWeaponData.h
+++ b/src/Ext/EffectType/Effect/AutoWeaponData.h
@@ -91,6 +91,8 @@ public:
 
 	bool AttackFromSpawnOwner = false; // 武器所属是母鸡
 
+	bool LaunchFromProjectile = false; // 武器从弹头附着点发射（广播专用）
+
 
 	virtual void Read(INIBufferReader* reader) override
 	{
@@ -133,6 +135,8 @@ public:
 
 		AttackFromSpawnOwner = reader->Get(title + "AttackFromSpawnOwner", AttackFromSpawnOwner);
 
+		LaunchFromProjectile = reader->Get(title + "LaunchFromProjectile", LaunchFromProjectile);
+
 		Enable = Data.Enable || EliteData.Enable;
 	}
 
@@ -152,6 +156,7 @@ public:
 			.Process(this->ReceiverAttack)
 			.Process(this->ReceiverOwnBullet)
 			.Process(this->AttackFromSpawnOwner)
+			.Process(this->LaunchFromProjectile)
 			.Success();
 	};
 

--- a/src/Ext/EffectType/Effect/AutoWeaponEffect.cpp
+++ b/src/Ext/EffectType/Effect/AutoWeaponEffect.cpp
@@ -294,7 +294,7 @@ void AutoWeaponEffect::OnUpdate()
 								pWeapon, *weaponData,
 								data.FireFLH, !Data->IsOnTurret, Data->IsOnTarget,
 								callback,
-								AE->FromWarhead ? AE->WarheadLocation : CoordStruct::Empty);
+								AE->FromWarhead && Data->LaunchFromProjectile ? AE->WarheadLocation : CoordStruct::Empty);
 							if (weaponLaunch)
 								ResetROF(pWeapon, weaponData, rofMultip);
 						}
@@ -358,7 +358,7 @@ void AutoWeaponEffect::OnUpdate()
 									pWeapon, *weaponData,
 									data.FireFLH, !Data->IsOnTurret, Data->IsOnTarget,
 									callback,
-									AE->FromWarhead ? AE->WarheadLocation : CoordStruct::Empty);
+									AE->FromWarhead && Data->LaunchFromProjectile ? AE->WarheadLocation : CoordStruct::Empty);
 								if (weaponLaunch)
 									ResetROF(pWeapon, weaponData, rofMultip);
 							}


### PR DESCRIPTION
专门用来修AutoWeapon AttackerMark被抛射体上的广播传播的情况