### PR TITLE
伪装AE 草稿版

### DIFF
--- a/src/Ext/BulletType/BulletStatus.h
+++ b/src/Ext/BulletType/BulletStatus.h
@@ -169,6 +169,14 @@ public:
 	// 正在被Vector强制位移
 	bool VectorForced = false;
 
+	// 弹体是否仍被 Vector 接管（复用 OnUpdate_Vector 每帧 MarginVectorOffset 的现成结果）
+	// Force=yes 的 Vector 必置 VectorForced；Force=no 的 Vector 以实际位移/冻结为准。
+	// 供 BulletClass_AI_PreDetonation_Vector hook 判断是否跳过引爆流程。
+	bool HasActiveVector()
+	{
+		return VectorForced || !_vectorResult.MoveDisp.IsEmpty() || _vectorResult.Freeze;
+	}
+
 	bool SpeedChanged = false; // 改变抛射体的速度
 	bool LocationLocked = false; // 锁定抛射体的位置
 

--- a/src/Ext/EffectType/AttachEffectData.h
+++ b/src/Ext/EffectType/AttachEffectData.h
@@ -27,7 +27,7 @@
 #include "Effect/RevengeData.h"
 #include "Effect/StackData.h"
 #include "Effect/StandData.h"
-#include "Effect/VectorData.h"
+#include "Effect/VectorDataReVibed.h"
 #include "Effect/TurretSpinData.h"
 #include "Effect/BodySpinData.h"
 #include "Effect/VampireData.h"

--- a/src/Ext/EffectType/Effect/VectorData.h
+++ b/src/Ext/EffectType/Effect/VectorData.h
@@ -37,7 +37,7 @@ public:
 	bool OriginNoUpdate = false;
 	bool Force = true;                  // yes=SetLocation 硬控，默认所有 Vector 模式 Force
 	bool Freeze = false;
-	bool AllowCircleTilt = false;        // yes=允许圆面使用 NormalVector 或地形倾斜
+	bool AllowCircleTilt = true;         // yes=允许圆面使用 NormalVector 或地形倾斜
 	CoordStruct NormalVector{};          // 圆面法向量（FLH 坐标系），F/L/H
 	CoordStruct NormalRandomF{};         // F 分量随机范围 .X=Min .Y=Max
 	CoordStruct NormalRandomL{};         // L 分量随机范围
@@ -76,7 +76,7 @@ public:
 	double CircleMaxAngle = 0.0;     // 角速度上限，0=不限
 	double CircleMinAngle = 0.0;     // 角速度下限，0=不限
 	CoordStruct CircleOrigin{};       // 圆心偏移（默认世界坐标，AllowOriginTilt=yes 时 FLH 旋转）
-	bool AllowOriginTilt = false;     // yes=圆心偏移跟随转轴倾斜
+	bool AllowOriginTilt = true;      // yes=圆心偏移跟随转轴倾斜
 	int CircleRandomRadiusMin = 0;    // 初始半径随机下限
 	int CircleRandomRadiusMax = 0;    // 初始半径随机上限
 	double CircleRandomAngleMin = 0.0; // 初始角速度随机下限
@@ -129,9 +129,9 @@ public:
 	double OriginNormalFAngleRMin = 0, OriginNormalFAngleRMax = 0, OriginNormalFAngleRMin2 = 0, OriginNormalFAngleRMax2 = 0;
 	double OriginNormalLAngleRMin = 0, OriginNormalLAngleRMax = 0, OriginNormalLAngleRMin2 = 0, OriginNormalLAngleRMax2 = 0;
 	double OriginNormalHAngleRMin = 0, OriginNormalHAngleRMax = 0, OriginNormalHAngleRMin2 = 0, OriginNormalHAngleRMax2 = 0;
-	bool OriginAllowCircleTilt = false;   // yes=大圆面跟随目标倾斜（Origin=Target 时有效）
+	bool OriginAllowCircleTilt = true;    // yes=大圆面跟随目标倾斜（Origin=Target 时有效）
 	CoordStruct OriginCircleOffset{};     // 圆心原点偏移（世界坐标）
-	bool OriginAllowOriginTilt = false;
+	bool OriginAllowOriginTilt = true;
 	bool OriginOriginNoUpdate = false;   // yes=圆心基座冻结在初始位置，不随目标移动
 	bool OriginLissajous = false;         // yes=独立圆面（Lissajous 模式），no=圆心位移叠加
 	VectorOrigin OriginOrigin = VectorOrigin::Self; // 圆心运动参考系
@@ -328,9 +328,9 @@ public:
 		OriginNormalFAnglePerStep = reader->Get(title + "Origin.NormalFAnglePerStep", 0.0);
 		OriginNormalLAnglePerStep = reader->Get(title + "Origin.NormalLAnglePerStep", 0.0);
 		OriginNormalHAnglePerStep = reader->Get(title + "Origin.NormalHAnglePerStep", 0.0);
-		OriginAllowCircleTilt = reader->Get(title + "Origin.AllowCircleTilt", false);
+		OriginAllowCircleTilt = reader->Get(title + "Origin.AllowCircleTilt", OriginAllowCircleTilt);
 		OriginCircleOffset = reader->Get(title + "Origin.CircleOrigin", OriginCircleOffset);
-		OriginAllowOriginTilt = reader->Get(title + "Origin.AllowOriginTilt", false);
+		OriginAllowOriginTilt = reader->Get(title + "Origin.AllowOriginTilt", OriginAllowOriginTilt);
 		OriginOriginNoUpdate = reader->Get(title + "Origin.OriginNoUpdate", false);
 		OriginLissajous = reader->Get(title + "Origin.Lissajous", false);
 		std::string originOriginStr = reader->Get(title + "Origin.Origin", std::string{ "Self" });

--- a/src/Ext/EffectType/Effect/VectorData.h
+++ b/src/Ext/EffectType/Effect/VectorData.h
@@ -37,7 +37,7 @@ public:
 	bool OriginNoUpdate = false;
 	bool Force = true;                  // yes=SetLocation 硬控，默认所有 Vector 模式 Force
 	bool Freeze = false;
-	bool AllowedTilt = false;           // yes=允许坐标系倾斜
+	bool AllowCircleTilt = false;        // yes=允许圆面使用 NormalVector 或地形倾斜
 	CoordStruct NormalVector{};          // 圆面法向量（FLH 坐标系），F/L/H
 	CoordStruct NormalRandomF{};         // F 分量随机范围 .X=Min .Y=Max
 	CoordStruct NormalRandomL{};         // L 分量随机范围
@@ -122,7 +122,7 @@ public:
 	double OriginNormalFAngleRMin = 0, OriginNormalFAngleRMax = 0, OriginNormalFAngleRMin2 = 0, OriginNormalFAngleRMax2 = 0;
 	double OriginNormalLAngleRMin = 0, OriginNormalLAngleRMax = 0, OriginNormalLAngleRMin2 = 0, OriginNormalLAngleRMax2 = 0;
 	double OriginNormalHAngleRMin = 0, OriginNormalHAngleRMax = 0, OriginNormalHAngleRMin2 = 0, OriginNormalHAngleRMax2 = 0;
-	bool OriginAllowedTilt = false;
+	bool OriginAllowCircleTilt = false;   // yes=大圆面跟随目标倾斜（Origin=Target 时有效）
 	CoordStruct OriginCircleOffset{};     // 圆心原点偏移（世界坐标）
 	bool OriginAllowOriginTilt = false;
 	bool OriginLissajous = false;         // yes=独立圆面（Lissajous 模式），no=圆心位移叠加
@@ -202,7 +202,7 @@ public:
 		OriginNoUpdate = reader->Get(title + "OriginNoUpdate", OriginNoUpdate);
 		Force = reader->Get(title + "Force", Force);
 		Freeze = reader->Get(title + "Freeze", Freeze);
-		AllowedTilt = reader->Get(title + "AllowedTilt", AllowedTilt);
+		AllowCircleTilt = reader->Get(title + "AllowCircleTilt", AllowCircleTilt);
 		NormalVector = reader->Get(title + "NormalVector", NormalVector);
 		NormalRandomF = reader->Get(title + "NormalRandomF", NormalRandomF);
 		NormalRandomL = reader->Get(title + "NormalRandomL", NormalRandomL);
@@ -288,19 +288,19 @@ public:
 		OriginReachTarget = reader->Get(title + "Origin.ReachTarget", false);
 		OriginSpeedEndOnReach = reader->Get(title + "Origin.SpeedEndOnReach", OriginSpeedEndOnReach);
 		OriginArcHeight = reader->Get(title + "Origin.ArcHeight", 0);
-		OriginTargetOffsetFMin = reader->Get(title + "Origin.TargetOffsetF.Min", OriginTargetOffsetFMin);
-		OriginTargetOffsetFMax = reader->Get(title + "Origin.TargetOffsetF.Max", OriginTargetOffsetFMax);
-		OriginTargetOffsetLMin = reader->Get(title + "Origin.TargetOffsetL.Min", OriginTargetOffsetLMin);
-		OriginTargetOffsetLMax = reader->Get(title + "Origin.TargetOffsetL.Max", OriginTargetOffsetLMax);
-		OriginTargetOffsetHMin = reader->Get(title + "Origin.TargetOffsetH.Min", OriginTargetOffsetHMin);
-		OriginTargetOffsetHMax = reader->Get(title + "Origin.TargetOffsetH.Max", OriginTargetOffsetHMax);
+		std::string originTargetOffsetFStr = reader->Get(title + "Origin.TargetOffsetF", std::string{""});
+		ParseMinMax(originTargetOffsetFStr, OriginTargetOffsetFMin, OriginTargetOffsetFMax);
+		std::string originTargetOffsetLStr = reader->Get(title + "Origin.TargetOffsetL", std::string{""});
+		ParseMinMax(originTargetOffsetLStr, OriginTargetOffsetLMin, OriginTargetOffsetLMax);
+		std::string originTargetOffsetHStr = reader->Get(title + "Origin.TargetOffsetH", std::string{""});
+		ParseMinMax(originTargetOffsetHStr, OriginTargetOffsetHMin, OriginTargetOffsetHMax);
 		OriginCircleRadius = reader->Get(title + "Origin.CircleRadius", -1);
 		OriginCircleSpeed = reader->Get(title + "Origin.CircleSpeed", 0);
 		OriginCircleAnglePerStep = reader->Get(title + "Origin.CircleAnglePerStep", 0.0);
-		OriginCircleRandomRadiusMin = reader->Get(title + "Origin.CircleRandomRadius.Min", OriginCircleRandomRadiusMin);
-		OriginCircleRandomRadiusMax = reader->Get(title + "Origin.CircleRandomRadius.Max", OriginCircleRandomRadiusMax);
-		OriginCircleRandomAngleMin = reader->Get(title + "Origin.CircleRandomAngle.Min", OriginCircleRandomAngleMin);
-		OriginCircleRandomAngleMax = reader->Get(title + "Origin.CircleRandomAngle.Max", OriginCircleRandomAngleMax);
+		std::string originCircleRandomRadiusStr = reader->Get(title + "Origin.CircleRandomRadius", std::string{""});
+		ParseMinMax(originCircleRandomRadiusStr, OriginCircleRandomRadiusMin, OriginCircleRandomRadiusMax);
+		std::string originCircleRandomAngleStr = reader->Get(title + "Origin.CircleRandomAngle", std::string{""});
+		ParseMinMaxDouble(originCircleRandomAngleStr, OriginCircleRandomAngleMin, OriginCircleRandomAngleMax);
 		OriginCircleRadiusGrow = reader->Get(title + "Origin.CircleRadiusGrow", 0);
 		OriginCircleMaxRadius = reader->Get(title + "Origin.CircleMaxRadius", 0);
 		OriginCircleMinRadius = reader->Get(title + "Origin.CircleMinRadius", 0);
@@ -313,8 +313,8 @@ public:
 		OriginNormalFAnglePerStep = reader->Get(title + "Origin.NormalFAnglePerStep", 0.0);
 		OriginNormalLAnglePerStep = reader->Get(title + "Origin.NormalLAnglePerStep", 0.0);
 		OriginNormalHAnglePerStep = reader->Get(title + "Origin.NormalHAnglePerStep", 0.0);
-		OriginAllowedTilt = reader->Get(title + "Origin.AllowedTilt", false);
-		OriginCircleOffset = reader->Get(title + "Origin.CircleOffset", OriginCircleOffset);
+		OriginAllowCircleTilt = reader->Get(title + "Origin.AllowCircleTilt", false);
+		OriginCircleOffset = reader->Get(title + "Origin.CircleOrigin", OriginCircleOffset);
 		OriginAllowOriginTilt = reader->Get(title + "Origin.AllowOriginTilt", false);
 		OriginLissajous = reader->Get(title + "Origin.Lissajous", false);
 		std::string originOriginStr = reader->Get(title + "Origin.Origin", std::string{ "Self" });
@@ -406,7 +406,7 @@ private:
 			.Process(this->OriginNoUpdate)
 			.Process(this->Force)
 			.Process(this->Freeze)
-			.Process(this->AllowedTilt)
+			.Process(this->AllowCircleTilt)
 			.Process(this->NormalVector)
 			.Process(this->NormalRandomF)
 			.Process(this->NormalRandomL)
@@ -472,7 +472,7 @@ private:
 			.Process(this->OriginNormalLAngleRMin2).Process(this->OriginNormalLAngleRMax2)
 			.Process(this->OriginNormalHAngleRMin).Process(this->OriginNormalHAngleRMax)
 			.Process(this->OriginNormalHAngleRMin2).Process(this->OriginNormalHAngleRMax2)
-			.Process(this->OriginAllowedTilt).Process(this->OriginCircleOffset)
+			.Process(this->OriginAllowCircleTilt).Process(this->OriginCircleOffset)
 			.Process(this->OriginAllowOriginTilt)
 
 			.Process(this->TargetFLH)

--- a/src/Ext/EffectType/Effect/VectorData.h
+++ b/src/Ext/EffectType/Effect/VectorData.h
@@ -149,6 +149,24 @@ public:
 	int TargetOffsetLMax = 0;
 	int TargetOffsetHMin = 0;
 	int TargetOffsetHMax = 0;
+	// 四参数版（TargetOffsetFRanges）：区间1复用上方 Min/Max，区间2独立存储，双区间50%取一
+	int TargetOffsetFMin2 = 0;
+	int TargetOffsetFMax2 = 0;
+	int TargetOffsetLMin2 = 0;
+	int TargetOffsetLMax2 = 0;
+	int TargetOffsetHMin2 = 0;
+	int TargetOffsetHMax2 = 0;
+	// 半径模式（TargetOffsetRadius）：与 F/L/H 互斥，全向随机落点
+	int TargetOffsetRadiusMin = 0;
+	int TargetOffsetRadiusMax = 0;
+	int TargetOffsetRadiusMin2 = 0;  // 四参数版（TargetOffsetRadiusRanges）区间2，区间1复用 Min/Max
+	int TargetOffsetRadiusMax2 = 0;
+	bool TargetOffsetSphere = false;   // yes=球面全向（含H），no=XY圆环+H用TargetOffsetH
+	// 角度限制（TargetOffsetAngles，仅圆环模式）：双区间，0度=目标点指向抛射体（近交点）
+	int TargetOffsetAngleMin = 0;
+	int TargetOffsetAngleMax = 0;
+	int TargetOffsetAngleMin2 = 0;
+	int TargetOffsetAngleMax2 = 0;
 
 	int LinearSpeed = -1;              // -1 = 读取单位 Speed
 	int RandomSpeedMin = 0;             // Speed 模式随机速度下限
@@ -350,6 +368,31 @@ public:
 		ParseMinMax(targetOffsetFStr, TargetOffsetFMin, TargetOffsetFMax);
 		ParseMinMax(targetOffsetLStr, TargetOffsetLMin, TargetOffsetLMax);
 		ParseMinMax(targetOffsetHStr, TargetOffsetHMin, TargetOffsetHMax);
+		{
+			// 四参数版：min1,max1,min2,max2。前两位覆盖区间1（Min/Max），后两位写区间2（Min2/Max2）
+			// 双区间全无效时保留两参数值（回退语义）
+			auto parse4i = [&](const char* key, int& m1, int& M1, int& m2, int& M2) {
+				auto s = reader->Get(title + key, std::string{ "" });
+				if (s.empty()) return;
+				std::vector<int> v;
+				std::stringstream ss(s);
+				std::string t;
+				while (std::getline(ss, t, ',')) v.push_back(std::stoi(t));
+				if (v.size() >= 4 && (v[0] < v[1] || v[2] < v[3]))
+				{
+					m1 = v[0]; M1 = v[1];
+					m2 = v[2]; M2 = v[3];
+				}
+			};
+			parse4i("TargetOffsetFRanges", TargetOffsetFMin, TargetOffsetFMax, TargetOffsetFMin2, TargetOffsetFMax2);
+			parse4i("TargetOffsetLRanges", TargetOffsetLMin, TargetOffsetLMax, TargetOffsetLMin2, TargetOffsetLMax2);
+			parse4i("TargetOffsetHRanges", TargetOffsetHMin, TargetOffsetHMax, TargetOffsetHMin2, TargetOffsetHMax2);
+			parse4i("TargetOffsetAngles", TargetOffsetAngleMin, TargetOffsetAngleMax, TargetOffsetAngleMin2, TargetOffsetAngleMax2);
+			parse4i("TargetOffsetRadiusRanges", TargetOffsetRadiusMin, TargetOffsetRadiusMax, TargetOffsetRadiusMin2, TargetOffsetRadiusMax2);
+		}
+		std::string targetOffsetRadiusStr = reader->Get(title + "TargetOffsetRadius", std::string{ "" });
+		ParseMinMax(targetOffsetRadiusStr, TargetOffsetRadiusMin, TargetOffsetRadiusMax);
+		TargetOffsetSphere = reader->Get(title + "TargetOffsetSphere", TargetOffsetSphere);
 		ReachTarget = reader->Get(title + "ReachTarget", ReachTarget);
 		ReachTargetEarlyEnd = reader->Get(title + "ReachTargetEarlyEnd", ReachTargetEarlyEnd);
 		ArcHeight = reader->Get(title + "ArcHeight", 0);
@@ -511,6 +554,21 @@ private:
 			.Process(this->TargetOffsetLMax)
 			.Process(this->TargetOffsetHMin)
 			.Process(this->TargetOffsetHMax)
+			.Process(this->TargetOffsetFMin2)
+			.Process(this->TargetOffsetFMax2)
+			.Process(this->TargetOffsetLMin2)
+			.Process(this->TargetOffsetLMax2)
+			.Process(this->TargetOffsetHMin2)
+			.Process(this->TargetOffsetHMax2)
+			.Process(this->TargetOffsetRadiusMin)
+			.Process(this->TargetOffsetRadiusMax)
+			.Process(this->TargetOffsetRadiusMin2)
+			.Process(this->TargetOffsetRadiusMax2)
+			.Process(this->TargetOffsetSphere)
+			.Process(this->TargetOffsetAngleMin)
+			.Process(this->TargetOffsetAngleMax)
+			.Process(this->TargetOffsetAngleMin2)
+			.Process(this->TargetOffsetAngleMax2)
 			.Process(this->ReachTarget)
 			.Process(this->ReachTargetEarlyEnd)
 			.Process(this->ArcHeight)

--- a/src/Ext/EffectType/Effect/VectorData.h
+++ b/src/Ext/EffectType/Effect/VectorData.h
@@ -24,7 +24,7 @@ public:
 
 	int TimeStep = 1;
 	int DisabledFrames = 0;              // 首帧快照后冻结 N 帧，不计入运动时间
-	bool SyncFacing = true;              // yes=抛射体朝运动方向/单位转动，no=抛射体朝目标
+	bool SyncFacing = false;             // yes=抛射体朝运动方向/单位转动，no=抛射体朝目标
 	bool OriginIsOnWorld = false;        // yes=OriginFLH用世界FLH(朝北)，不使用单位/弹体朝向
 	bool OriginIsOnBody = false;          // yes=单位取车身PrimaryFacing，无视炮塔TurretFacing
 
@@ -96,11 +96,12 @@ public:
 	double OriginAnglePerStep = 0.0;    // 自旋角度（°/step）
 	// Speed / ReachTarget 模式
 	CoordStruct OriginTargetFLH{};        // 追踪目标 FLH
-	int OriginInitialSpeed = -1;          // 初始速度，-1=读取单位Speed
+	int OriginLinearSpeed = -1;          // 初始速度，-1=读取单位Speed
 	int OriginAcceleration = 0;           // 加速度（lepton/step²）
 	int OriginMaxSpeed = -1;              // 最大速度，-1=不限
 	int OriginMinSpeed = -1;              // 最小速度，-1=不限
 	bool OriginReachTarget = false;       // 到达模式
+	bool OriginSpeedEndOnReach = true;    // Speed模式抵达目标即结束AE
 	int OriginArcHeight = 0;            // 到达模式弧高
 	int OriginTargetOffsetFMin = 0, OriginTargetOffsetFMax = 0;
 	int OriginTargetOffsetLMin = 0, OriginTargetOffsetLMax = 0;
@@ -140,12 +141,13 @@ public:
 	int TargetOffsetHMin = 0;
 	int TargetOffsetHMax = 0;
 
-	int InitialSpeed = -1;              // -1 = 读取单位 Speed
+	int LinearSpeed = -1;              // -1 = 读取单位 Speed
 	int RandomSpeedMin = 0;             // Speed 模式随机速度下限
 	int RandomSpeedMax = 0;             // Speed 模式随机速度上限
 	int MaxSpeed = -1;                  // -1 = 不限
 	int MinSpeed = -1;                  // -1 = 不限
 	int Acceleration = 0;               // 每帧速度增量
+	bool SpeedEndOnReach = true;        // 抵达目标坐标点即强制结束AE（修复飞越后抽搐）
 
 	// ========================================================================
 	// ReachTarget 模式（剩余帧数强制到达）
@@ -154,6 +156,8 @@ public:
 	bool ReachTarget = false;           // 与 TargetFLH 配合使用
 	int ReachTargetEarlyEnd = 0;        // 提前结束 AE 的帧数，0=禁用，>0 时提前 N 帧交还引擎
 	int ArcHeight = 0;                  // ReachTarget 弧高（lepton），0=直线，正=上凸
+	double ArcPeakPercent = 50.0;       // 弧高点所在 Duration 百分比（0-100），默认50=中点
+	Point2D ArcPeakRandomPercent{ 0, 0 };// 随机弧高百分比范围 (Min, Max)
 	int ArcRandomHeightMin = 0;         // 随机弧高下限
 	int ArcRandomHeightMax = 0;         // 随机弧高上限
 	double ArcRotation = 0.0;           // 弧面旋转角（°），0=默认朝上，顺时针
@@ -277,11 +281,12 @@ public:
 		OriginGrowRate = reader->Get(title + "Origin.GrowRate", OriginGrowRate);
 		OriginAnglePerStep = reader->Get(title + "Origin.AnglePerStep", 0.0);
 		OriginTargetFLH = reader->Get(title + "Origin.TargetFLH", OriginTargetFLH);
-		OriginInitialSpeed = reader->Get(title + "Origin.InitialSpeed", -1);
+		OriginLinearSpeed = reader->Get(title + "Origin.LinearSpeed", -1);
 		OriginAcceleration = reader->Get(title + "Origin.Acceleration", 0);
 		OriginMaxSpeed = reader->Get(title + "Origin.MaxSpeed", -1);
 		OriginMinSpeed = reader->Get(title + "Origin.MinSpeed", -1);
 		OriginReachTarget = reader->Get(title + "Origin.ReachTarget", false);
+		OriginSpeedEndOnReach = reader->Get(title + "Origin.SpeedEndOnReach", OriginSpeedEndOnReach);
 		OriginArcHeight = reader->Get(title + "Origin.ArcHeight", 0);
 		OriginTargetOffsetFMin = reader->Get(title + "Origin.TargetOffsetF.Min", OriginTargetOffsetFMin);
 		OriginTargetOffsetFMax = reader->Get(title + "Origin.TargetOffsetF.Max", OriginTargetOffsetFMax);
@@ -330,23 +335,27 @@ public:
 		ReachTarget = reader->Get(title + "ReachTarget", ReachTarget);
 		ReachTargetEarlyEnd = reader->Get(title + "ReachTargetEarlyEnd", ReachTargetEarlyEnd);
 		ArcHeight = reader->Get(title + "ArcHeight", 0);
-		std::string arcRandomHeightStr = reader->Get(title + "ArcRandomHeight", std::string{ "" });
+		ArcPeakPercent = reader->Get(title + "ArcPeakPercent", ArcPeakPercent);
+		ArcPeakRandomPercent = reader->Get(title + "RandomArcPeakPercent", ArcPeakRandomPercent);
+		std::string arcRandomHeightStr = reader->Get(title + "RandomArcHeight", std::string{ "" });
 		ParseMinMax(arcRandomHeightStr, ArcRandomHeightMin, ArcRandomHeightMax);
 		ArcRotation = reader->Get(title + "ArcRotation", 0.0);
-		std::string arcRandomRotationStr = reader->Get(title + "ArcRandomRotation", std::string{ "" });
+		std::string arcRandomRotationStr = reader->Get(title + "RandomArcRotation", std::string{ "" });
 		ParseMinMaxDouble(arcRandomRotationStr, ArcRandomRotationMin, ArcRandomRotationMax);
 		AllowFallingDestroy = reader->Get(title + "AllowFallingDestroy", AllowFallingDestroy);
 		FallingDestroyHeight = reader->Get(title + "FallingDestroyHeight", FallingDestroyHeight);
 
 		// --- 速度 ---
-		InitialSpeed = reader->Get(title + "InitialSpeed", -1);
+		LinearSpeed = reader->Get(title + "LinearSpeed", -1);
 		std::string randomSpeedStr = reader->Get(title + "RandomSpeed", std::string{ "" });
 		ParseMinMax(randomSpeedStr, RandomSpeedMin, RandomSpeedMax);
 		MaxSpeed = reader->Get(title + "MaxSpeed", -1);
 		MinSpeed = reader->Get(title + "MinSpeed", -1);
 		Acceleration = reader->Get(title + "Acceleration", Acceleration);
+		SpeedEndOnReach = reader->Get(title + "SpeedEndOnReach", SpeedEndOnReach);
 
-		Enable = !MoveTo.IsEmpty() || !TargetFLH.IsEmpty() || Freeze || ReachTarget
+		Enable = !MoveTo.IsEmpty() || Freeze || ReachTarget
+			|| (LinearSpeed >= 0)
 			|| (CircleRadius > 0) || (CircleSpeed != 0) || (CircleAnglePerStep > 0.0)
 			|| (CircleRandomRadiusMax > CircleRandomRadiusMin)
 			|| (CircleRandomAngleMax > CircleRandomAngleMin)
@@ -439,7 +448,8 @@ private:
 			.Process(this->CircleEndOnMinRadius)
 			.Process(this->OriginMoveTo).Process(this->OriginGrowRate)
 			.Process(this->OriginAnglePerStep).Process(this->OriginTargetFLH)
-			.Process(this->OriginInitialSpeed).Process(this->OriginReachTarget)
+			.Process(this->OriginLinearSpeed).Process(this->OriginReachTarget)
+			.Process(this->OriginSpeedEndOnReach)
 			.Process(this->OriginArcHeight)
 			.Process(this->OriginTargetOffsetFMin).Process(this->OriginTargetOffsetFMax)
 			.Process(this->OriginTargetOffsetLMin).Process(this->OriginTargetOffsetLMax)
@@ -475,6 +485,8 @@ private:
 			.Process(this->ReachTarget)
 			.Process(this->ReachTargetEarlyEnd)
 			.Process(this->ArcHeight)
+			.Process(this->ArcPeakPercent)
+			.Process(this->ArcPeakRandomPercent)
 			.Process(this->ArcRandomHeightMin)
 			.Process(this->ArcRandomHeightMax)
 			.Process(this->ArcRotation)
@@ -483,12 +495,13 @@ private:
 			.Process(this->AllowFallingDestroy)
 			.Process(this->FallingDestroyHeight)
 
-			.Process(this->InitialSpeed)
+			.Process(this->LinearSpeed)
 			.Process(this->RandomSpeedMin)
 			.Process(this->RandomSpeedMax)
 			.Process(this->MaxSpeed)
 			.Process(this->MinSpeed)
-			.Process(this->Acceleration);
+			.Process(this->Acceleration)
+			.Process(this->SpeedEndOnReach);
 		return stream.Success();
 	};
 

--- a/src/Ext/EffectType/Effect/VectorData.h
+++ b/src/Ext/EffectType/Effect/VectorData.h
@@ -51,6 +51,7 @@ public:
 	double NormalLAngleRMin2 = 0.0, NormalLAngleRMax2 = 0.0;
 	double NormalHAngleRMin = 0.0, NormalHAngleRMax = 0.0;
 	double NormalHAngleRMin2 = 0.0, NormalHAngleRMax2 = 0.0;
+	double Lissajous = 0.0;           // 小圆圆周 F 轴偏移角速度（°/step），0=不偏移
 
 	// ========================================================================
 	// MoveTo 模式（纯 FLH 位移 + GrowRate）
@@ -133,7 +134,7 @@ public:
 	CoordStruct OriginCircleOffset{};     // 圆心原点偏移（世界坐标）
 	bool OriginAllowOriginTilt = true;
 	bool OriginOriginNoUpdate = false;   // yes=圆心基座冻结在初始位置，不随目标移动
-	bool OriginLissajous = false;         // yes=独立圆面（Lissajous 模式），no=圆心位移叠加
+	double OriginLissajous = 0.0;        // 大圆圆周 F 轴偏移角速度（°/step），0=不偏移
 	VectorOrigin OriginOrigin = VectorOrigin::Self; // 圆心运动参考系
 	CoordStruct OriginOriginFLH{};      // OriginOrigin=FLH 时的 FLH 偏移
 
@@ -232,6 +233,7 @@ public:
 			parse4("NormalLAngleRanges", NormalLAngleRMin, NormalLAngleRMax, NormalLAngleRMin2, NormalLAngleRMax2);
 			parse4("NormalHAngleRanges", NormalHAngleRMin, NormalHAngleRMax, NormalHAngleRMin2, NormalHAngleRMax2);
 		}
+		Lissajous = reader->Get(title + "Lissajous", 0.0);
 
 		// --- MoveTo ---
 		MoveTo = reader->Get(title + "MoveTo", MoveTo);
@@ -332,7 +334,7 @@ public:
 		OriginCircleOffset = reader->Get(title + "Origin.CircleOrigin", OriginCircleOffset);
 		OriginAllowOriginTilt = reader->Get(title + "Origin.AllowOriginTilt", OriginAllowOriginTilt);
 		OriginOriginNoUpdate = reader->Get(title + "Origin.OriginNoUpdate", false);
-		OriginLissajous = reader->Get(title + "Origin.Lissajous", false);
+		OriginLissajous = reader->Get(title + "Origin.Lissajous", 0.0);
 		std::string originOriginStr = reader->Get(title + "Origin.Origin", std::string{ "Self" });
 		if (originOriginStr == "Launcher") OriginOrigin = VectorOrigin::Launcher;
 		else if (originOriginStr == "Target") OriginOrigin = VectorOrigin::Target;
@@ -436,6 +438,7 @@ private:
 			.Process(this->NormalLAngleRMin2).Process(this->NormalLAngleRMax2)
 			.Process(this->NormalHAngleRMin).Process(this->NormalHAngleRMax)
 			.Process(this->NormalHAngleRMin2).Process(this->NormalHAngleRMax2)
+			.Process(this->Lissajous)
 
 			.Process(this->MoveTo)
 			.Process(this->GrowRate)
@@ -497,6 +500,9 @@ private:
 			.Process(this->OriginNormalHAngleRMin2).Process(this->OriginNormalHAngleRMax2)
 			.Process(this->OriginAllowCircleTilt).Process(this->OriginCircleOffset)
 			.Process(this->OriginAllowOriginTilt).Process(this->OriginOriginNoUpdate)
+			.Process(this->OriginLissajous)
+			.Process(this->OriginOrigin)
+			.Process(this->OriginOriginFLH)
 
 			.Process(this->TargetFLH)
 			.Process(this->TargetOffsetFMin)

--- a/src/Ext/EffectType/Effect/VectorData.h
+++ b/src/Ext/EffectType/Effect/VectorData.h
@@ -103,6 +103,13 @@ public:
 	bool OriginReachTarget = false;       // 到达模式
 	bool OriginSpeedEndOnReach = true;    // Speed模式抵达目标即结束AE
 	int OriginArcHeight = 0;            // 到达模式弧高
+	double OriginArcPeakPercent = 50.0; // 弧高点百分比（0-100），默认50=中点
+	Point2D OriginArcPeakRandomPercent{ 0, 0 };// 随机弧高点百分比
+	int OriginArcRandomHeightMin = 0;   // 随机弧高下限
+	int OriginArcRandomHeightMax = 0;   // 随机弧高上限
+	double OriginArcRotation = 0.0;     // 弧面旋转角（°），0=朝上
+	double OriginArcRandomRotationMin = 0.0;// 随机旋转下限
+	double OriginArcRandomRotationMax = 0.0;// 随机旋转上限
 	int OriginTargetOffsetFMin = 0, OriginTargetOffsetFMax = 0;
 	int OriginTargetOffsetLMin = 0, OriginTargetOffsetLMax = 0;
 	int OriginTargetOffsetHMin = 0, OriginTargetOffsetHMax = 0;
@@ -125,6 +132,7 @@ public:
 	bool OriginAllowCircleTilt = false;   // yes=大圆面跟随目标倾斜（Origin=Target 时有效）
 	CoordStruct OriginCircleOffset{};     // 圆心原点偏移（世界坐标）
 	bool OriginAllowOriginTilt = false;
+	bool OriginOriginNoUpdate = false;   // yes=圆心基座冻结在初始位置，不随目标移动
 	bool OriginLissajous = false;         // yes=独立圆面（Lissajous 模式），no=圆心位移叠加
 	VectorOrigin OriginOrigin = VectorOrigin::Self; // 圆心运动参考系
 	CoordStruct OriginOriginFLH{};      // OriginOrigin=FLH 时的 FLH 偏移
@@ -288,6 +296,13 @@ public:
 		OriginReachTarget = reader->Get(title + "Origin.ReachTarget", false);
 		OriginSpeedEndOnReach = reader->Get(title + "Origin.SpeedEndOnReach", OriginSpeedEndOnReach);
 		OriginArcHeight = reader->Get(title + "Origin.ArcHeight", 0);
+		OriginArcPeakPercent = reader->Get(title + "Origin.ArcPeakPercent", OriginArcPeakPercent);
+		OriginArcPeakRandomPercent = reader->Get(title + "Origin.RandomArcPeakPercent", OriginArcPeakRandomPercent);
+		std::string originArcRandomHeightStr = reader->Get(title + "Origin.RandomArcHeight", std::string{ "" });
+		ParseMinMax(originArcRandomHeightStr, OriginArcRandomHeightMin, OriginArcRandomHeightMax);
+		OriginArcRotation = reader->Get(title + "Origin.ArcRotation", 0.0);
+		std::string originArcRandomRotationStr = reader->Get(title + "Origin.RandomArcRotation", std::string{ "" });
+		ParseMinMaxDouble(originArcRandomRotationStr, OriginArcRandomRotationMin, OriginArcRandomRotationMax);
 		std::string originTargetOffsetFStr = reader->Get(title + "Origin.TargetOffsetF", std::string{""});
 		ParseMinMax(originTargetOffsetFStr, OriginTargetOffsetFMin, OriginTargetOffsetFMax);
 		std::string originTargetOffsetLStr = reader->Get(title + "Origin.TargetOffsetL", std::string{""});
@@ -316,6 +331,7 @@ public:
 		OriginAllowCircleTilt = reader->Get(title + "Origin.AllowCircleTilt", false);
 		OriginCircleOffset = reader->Get(title + "Origin.CircleOrigin", OriginCircleOffset);
 		OriginAllowOriginTilt = reader->Get(title + "Origin.AllowOriginTilt", false);
+		OriginOriginNoUpdate = reader->Get(title + "Origin.OriginNoUpdate", false);
 		OriginLissajous = reader->Get(title + "Origin.Lissajous", false);
 		std::string originOriginStr = reader->Get(title + "Origin.Origin", std::string{ "Self" });
 		if (originOriginStr == "Launcher") OriginOrigin = VectorOrigin::Launcher;
@@ -451,6 +467,13 @@ private:
 			.Process(this->OriginLinearSpeed).Process(this->OriginReachTarget)
 			.Process(this->OriginSpeedEndOnReach)
 			.Process(this->OriginArcHeight)
+			.Process(this->OriginArcPeakPercent)
+			.Process(this->OriginArcPeakRandomPercent)
+			.Process(this->OriginArcRandomHeightMin)
+			.Process(this->OriginArcRandomHeightMax)
+			.Process(this->OriginArcRotation)
+			.Process(this->OriginArcRandomRotationMin)
+			.Process(this->OriginArcRandomRotationMax)
 			.Process(this->OriginTargetOffsetFMin).Process(this->OriginTargetOffsetFMax)
 			.Process(this->OriginTargetOffsetLMin).Process(this->OriginTargetOffsetLMax)
 			.Process(this->OriginTargetOffsetHMin).Process(this->OriginTargetOffsetHMax)
@@ -473,7 +496,7 @@ private:
 			.Process(this->OriginNormalHAngleRMin).Process(this->OriginNormalHAngleRMax)
 			.Process(this->OriginNormalHAngleRMin2).Process(this->OriginNormalHAngleRMax2)
 			.Process(this->OriginAllowCircleTilt).Process(this->OriginCircleOffset)
-			.Process(this->OriginAllowOriginTilt)
+			.Process(this->OriginAllowOriginTilt).Process(this->OriginOriginNoUpdate)
 
 			.Process(this->TargetFLH)
 			.Process(this->TargetOffsetFMin)

--- a/src/Ext/EffectType/Effect/VectorDataReVibed.h
+++ b/src/Ext/EffectType/Effect/VectorDataReVibed.h
@@ -1,0 +1,625 @@
+#pragma once
+// ============================================================================
+// VectorReVibed — 数据层（从零重写版）
+//
+// 文件名带 ReVibed 后缀以与旧版（VectorData.h）隔离；类名保持 VectorData，
+// 注册键/INI 前缀与旧版完全一致（Vector.*），替换时仅切换 include 路径。
+//
+// 行为等价铁律：本文件所有 INI 标签名、默认值、解析语义与旧版逐字一致，
+// 不得借重写之机改动任何标签行为。Vector.xlsx 作为标签核对清单。
+// ============================================================================
+
+#include <string>
+#include <vector>
+#include <cmath>
+#include <sstream>
+
+#include <GeneralStructures.h>
+
+#include <Ext/EffectType/Effect/EffectData.h>
+#include <Ext/Helper/CastEx.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+class VectorData : public EffectData
+{
+public:
+	EFFECT_DATA(Vector);
+
+	// ========================================================================
+	// 通用设定
+	// ========================================================================
+
+	int TimeStep = 1;
+	int DisabledFrames = 0;              // 首帧快照后冻结 N 帧，不计入运动时间
+	bool SyncFacing = false;             // yes=抛射体朝运动方向/单位转动，no=抛射体朝目标
+	bool OriginIsOnWorld = false;        // yes=OriginFLH用世界FLH(朝北)，不使用单位/弹体朝向
+	bool OriginIsOnBody = false;         // yes=单位取车身PrimaryFacing，无视炮塔TurretFacing
+
+	enum class VectorOrigin : int
+	{
+		Self = 0, Launcher = 1, Target = 2, Source = 3,
+	};
+	VectorOrigin Origin = VectorOrigin::Self;
+	CoordStruct OriginFLH{};
+	bool OriginNoUpdate = false;
+	bool Force = true;                  // yes=SetLocation 硬控，默认所有 Vector 模式 Force
+	bool Freeze = false;
+	bool AllowCircleTilt = true;         // yes=允许圆面使用 NormalVector 或地形倾斜
+
+	// ========================================================================
+	// NormalVector 圆面法线
+	// ========================================================================
+
+	CoordStruct NormalVector{};          // 圆面法向量（FLH 坐标系），F/L/H
+	CoordStruct NormalRandomF{};         // F 分量随机范围 .X=Min .Y=Max
+	CoordStruct NormalRandomL{};         // L 分量随机范围
+	CoordStruct NormalRandomH{};         // H 分量随机范围
+	double NormalFAnglePerStep = 0.0;   // 绕 F 轴角速度 (°/step)，常数模式
+	double NormalLAnglePerStep = 0.0;   // 绕 L 轴
+	double NormalHAnglePerStep = 0.0;   // 绕 H 轴
+	double NormalFAngleRMin = 0.0, NormalFAngleRMax = 0.0;     // 绕 F 角速度区间1
+	double NormalFAngleRMin2 = 0.0, NormalFAngleRMax2 = 0.0;  // 绕 F 角速度区间2
+	double NormalLAngleRMin = 0.0, NormalLAngleRMax = 0.0;
+	double NormalLAngleRMin2 = 0.0, NormalLAngleRMax2 = 0.0;
+	double NormalHAngleRMin = 0.0, NormalHAngleRMax = 0.0;
+	double NormalHAngleRMin2 = 0.0, NormalHAngleRMax2 = 0.0;
+	double Lissajous = 0.0;            // 小圆圆周 F 轴偏移角速度（°/step），0=不偏移
+
+	// ========================================================================
+	// MoveTo 模式（纯 FLH 位移 + GrowRate）
+	// ========================================================================
+
+	CoordStruct MoveTo{};
+	CoordStruct GrowRate{};             // 每帧 FLH 增量（呼吸/螺旋/振幅）
+	double AnglePerStep = 0.0;         // MoveTo 模式角度自增（°/step）
+
+	// ========================================================================
+	// Circle 模式（圆周，独立于 MoveTo）
+	// 三选二：Radius / Speed / AnglePerStep，未设的一项自动推算
+	// 圆心 = Origin（同 Origin 标签，动态刷新除非 NoUpdate）
+	// ========================================================================
+
+	int CircleRadius = -1;              // 圆半径（lepton），-1=自动取当前XY距离
+	int CircleSpeed = 0;               // 线速度（lepton/step沿圆周），0=不由它推算
+	int CircleSpeedAcceleration = 0;   // 线速度每步加速度
+	int CircleMaxSpeed = 0;            // 线速度上限，0=不限
+	int CircleMinSpeed = 0;            // 线速度下限，0=不限
+	double CircleAnglePerStep = 0.0;  // 角速度（°/step），0=不由它推算
+	double CircleAngleAcceleration = 0.0; // 角速度每步加速度
+	double CircleMaxAngle = 0.0;     // 角速度上限，0=不限
+	double CircleMinAngle = 0.0;     // 角速度下限，0=不限
+	CoordStruct CircleOrigin{};       // 圆心偏移（默认世界坐标，AllowOriginTilt=yes 时 FLH 旋转）
+	bool AllowOriginTilt = true;      // yes=圆心偏移跟随转轴倾斜
+	int CircleRandomRadiusMin = 0;    // 初始半径随机下限
+	int CircleRandomRadiusMax = 0;    // 初始半径随机上限
+	double CircleRandomAngleMin = 0.0; // 初始角速度随机下限
+	double CircleRandomAngleMax = 0.0; // 初始角速度随机上限
+	double CircleRandomAngleMin2 = 0.0; // 第二区间下限（4 值模式）
+	double CircleRandomAngleMax2 = 0.0; // 第二区间上限（4 值模式）
+	int CircleRadiusGrow = 0;          // 半径每步增长量（lepton/step），正=外扩，负=内缩
+	int CircleMaxRadius = 0;           // 半径上限，0=不限
+	int CircleMinRadius = 0;           // 半径下限，0=不限
+	bool CircleEndOnMaxRadius = false; // 半径达到上限时结束 AE
+	bool CircleEndOnMinRadius = false; // 半径达到下限时结束 AE
+
+	// ========================================================================
+	// 圆心运动（Vector.Origin.* 系列，Circle 模式专用）
+	// ========================================================================
+
+	// MoveTo 模式
+	CoordStruct OriginMoveTo{};           // 圆心 FLH 位移（lepton/step）
+	CoordStruct OriginGrowRate{};         // 每步增量
+	double OriginAnglePerStep = 0.0;    // 自旋角度（°/step）
+	// Speed / ReachTarget 模式
+	CoordStruct OriginTargetFLH{};        // 追踪目标 FLH
+	int OriginLinearSpeed = -1;          // 初始速度，-1=读取单位Speed
+	int OriginAcceleration = 0;           // 加速度（lepton/step²）
+	int OriginMaxSpeed = -1;              // 最大速度，-1=不限
+	int OriginMinSpeed = -1;              // 最小速度，-1=不限
+	bool OriginReachTarget = false;       // 到达模式
+	bool OriginSpeedEndOnReach = true;    // Speed模式抵达目标即结束AE
+	int OriginArcHeight = 0;            // 到达模式弧高
+	double OriginArcPeakPercent = 50.0; // 弧高点百分比（0-100），默认50=中点
+	Point2D OriginArcPeakRandomPercent{ 0, 0 };// 随机弧高点百分比
+	int OriginArcRandomHeightMin = 0;   // 随机弧高下限
+	int OriginArcRandomHeightMax = 0;   // 随机弧高上限
+	double OriginArcRotation = 0.0;     // 弧面旋转角（°），0=朝上
+	double OriginArcRandomRotationMin = 0.0;// 随机旋转下限
+	double OriginArcRandomRotationMax = 0.0;// 随机旋转上限
+	int OriginTargetOffsetFMin = 0, OriginTargetOffsetFMax = 0;
+	int OriginTargetOffsetLMin = 0, OriginTargetOffsetLMax = 0;
+	int OriginTargetOffsetHMin = 0, OriginTargetOffsetHMax = 0;
+	// Circle 模式
+	int OriginCircleRadius = -1;
+	int OriginCircleSpeed = 0;
+	double OriginCircleAnglePerStep = 0.0;
+	int OriginCircleRandomRadiusMin = 0, OriginCircleRandomRadiusMax = 0;
+	double OriginCircleRandomAngleMin = 0, OriginCircleRandomAngleMax = 0;
+	int OriginCircleRadiusGrow = 0;
+	int OriginCircleMaxRadius = 0, OriginCircleMinRadius = 0;
+	bool OriginCircleEndOnMaxRadius = false, OriginCircleEndOnMinRadius = false;
+	// 法线
+	CoordStruct OriginNormalVector{};
+	CoordStruct OriginNormalRandomF{}, OriginNormalRandomL{}, OriginNormalRandomH{};
+	double OriginNormalFAnglePerStep = 0.0, OriginNormalLAnglePerStep = 0.0, OriginNormalHAnglePerStep = 0.0;
+	double OriginNormalFAngleRMin = 0, OriginNormalFAngleRMax = 0, OriginNormalFAngleRMin2 = 0, OriginNormalFAngleRMax2 = 0;
+	double OriginNormalLAngleRMin = 0, OriginNormalLAngleRMax = 0, OriginNormalLAngleRMin2 = 0, OriginNormalLAngleRMax2 = 0;
+	double OriginNormalHAngleRMin = 0, OriginNormalHAngleRMax = 0, OriginNormalHAngleRMin2 = 0, OriginNormalHAngleRMax2 = 0;
+	// 圆心通用
+	bool OriginAllowCircleTilt = true;    // yes=大圆面跟随目标倾斜（Origin=Target 时有效）
+	CoordStruct OriginCircleOffset{};     // 圆心原点偏移（世界坐标）
+	bool OriginAllowOriginTilt = true;
+	bool OriginOriginNoUpdate = false;   // yes=圆心基座冻结在初始位置，不随目标移动
+	double OriginLissajous = 0.0;        // 大圆圆周 F 轴偏移角速度（°/step），0=不偏移
+	VectorOrigin OriginOrigin = VectorOrigin::Self; // 圆心运动参考系
+	CoordStruct OriginOriginFLH{};      // OriginOrigin=FLH 时的 FLH 偏移
+
+	// ========================================================================
+	// Speed 模式（直线追踪 + 加速度）
+	// ========================================================================
+
+	CoordStruct TargetFLH{};
+	int TargetOffsetFMin = 0;
+	int TargetOffsetFMax = 0;
+	int TargetOffsetLMin = 0;
+	int TargetOffsetLMax = 0;
+	int TargetOffsetHMin = 0;
+	int TargetOffsetHMax = 0;
+	// 四参数版（TargetOffsetFRanges）：区间1复用上方 Min/Max，区间2独立存储，双区间50%取一
+	int TargetOffsetFMin2 = 0;
+	int TargetOffsetFMax2 = 0;
+	int TargetOffsetLMin2 = 0;
+	int TargetOffsetLMax2 = 0;
+	int TargetOffsetHMin2 = 0;
+	int TargetOffsetHMax2 = 0;
+	// 半径模式（TargetOffsetRadius）：与 F/L/H 互斥，全向随机落点
+	int TargetOffsetRadiusMin = 0;
+	int TargetOffsetRadiusMax = 0;
+	int TargetOffsetRadiusMin2 = 0;  // 四参数版（TargetOffsetRadiusRanges）区间2，区间1复用 Min/Max
+	int TargetOffsetRadiusMax2 = 0;
+	bool TargetOffsetSphere = false;   // yes=球面全向（含H），no=XY圆环+H用TargetOffsetH
+	// 角度限制（TargetOffsetAngles，仅圆环模式）：双区间，0度=目标点指向抛射体（近交点）
+	int TargetOffsetAngleMin = 0;
+	int TargetOffsetAngleMax = 0;
+	int TargetOffsetAngleMin2 = 0;
+	int TargetOffsetAngleMax2 = 0;
+
+	int LinearSpeed = -1;              // -1 = 读取单位 Speed
+	int RandomSpeedMin = 0;             // Speed 模式随机速度下限
+	int RandomSpeedMax = 0;             // Speed 模式随机速度上限
+	int MaxSpeed = -1;                  // -1 = 不限
+	int MinSpeed = -1;                  // -1 = 不限
+	int Acceleration = 0;               // 每帧速度增量
+	bool SpeedEndOnReach = true;        // 抵达目标坐标点即强制结束AE（修复飞越后抽搐）
+
+	// ========================================================================
+	// ReachTarget 模式（剩余帧数强制到达）
+	// ========================================================================
+
+	bool ReachTarget = false;           // 与 TargetFLH 配合使用
+	int ReachTargetEarlyEnd = 0;        // 提前结束 AE 的帧数，0=禁用，>0 时提前 N 帧交还引擎
+	int ArcHeight = 0;                  // ReachTarget 弧高（lepton），0=直线，正=上凸
+	double ArcPeakPercent = 50.0;       // 弧高点所在 Duration 百分比（0-100），默认50=中点
+	Point2D ArcPeakRandomPercent{ 0, 0 };// 随机弧高百分比范围 (Min, Max)
+	int ArcRandomHeightMin = 0;         // 随机弧高下限
+	int ArcRandomHeightMax = 0;         // 随机弧高上限
+	double ArcRotation = 0.0;           // 弧面旋转角（°），0=默认朝上，顺时针
+	double ArcRandomRotationMin = 0.0;  // 随机旋转下限
+	double ArcRandomRotationMax = 0.0;  // 随机旋转上限
+	bool AllowFallingDestroy = false;   // 向量结束时摔死
+	int FallingDestroyHeight = Unsorted::LevelHeight;   // 摔死高度
+
+	// ========================================================================
+	// 内部
+	// ========================================================================
+
+	VectorData() : EffectData()
+	{
+		AffectBuilding = false;
+	}
+
+	virtual void Read(INIBufferReader* reader) override
+	{
+		Read(reader, "Vector.");
+	}
+
+	virtual void Read(INIBufferReader* reader, std::string title) override
+	{
+		EffectData::Read(reader, title);
+
+		// --- 通用 ---
+		TimeStep = reader->Get(title + "TimeStep", 1);
+		if (TimeStep < 1) TimeStep = 1;
+		DisabledFrames = reader->Get(title + "DisabledFrames", 0);
+		SyncFacing = reader->Get(title + "SyncFacing", SyncFacing);
+		OriginIsOnWorld = reader->Get(title + "OriginIsOnWorld", OriginIsOnWorld);
+		OriginIsOnBody = reader->Get(title + "OriginIsOnBody", OriginIsOnBody);
+
+		std::string originStr = reader->Get(title + "Origin", std::string{ "Self" });
+		if (originStr == "Launcher") Origin = VectorOrigin::Launcher;
+		else if (originStr == "Target") Origin = VectorOrigin::Target;
+		else if (originStr == "Source") Origin = VectorOrigin::Source;
+		else Origin = VectorOrigin::Self;
+
+		OriginFLH = reader->Get(title + "OriginFLH", OriginFLH);
+		OriginNoUpdate = reader->Get(title + "OriginNoUpdate", OriginNoUpdate);
+		Force = reader->Get(title + "Force", Force);
+		Freeze = reader->Get(title + "Freeze", Freeze);
+		AllowCircleTilt = reader->Get(title + "AllowCircleTilt", AllowCircleTilt);
+		NormalVector = reader->Get(title + "NormalVector", NormalVector);
+		NormalRandomF = reader->Get(title + "NormalRandomF", NormalRandomF);
+		NormalRandomL = reader->Get(title + "NormalRandomL", NormalRandomL);
+		NormalRandomH = reader->Get(title + "NormalRandomH", NormalRandomH);
+		NormalFAnglePerStep = reader->Get(title + "NormalFAnglePerStep", 0.0);
+		NormalLAnglePerStep = reader->Get(title + "NormalLAnglePerStep", 0.0);
+		NormalHAnglePerStep = reader->Get(title + "NormalHAnglePerStep", 0.0);
+		{
+			auto parse4 = [&](const char* key, double& m1, double& M1, double& m2, double& M2) {
+				auto s = reader->Get(title + key, std::string{ "" });
+				if (s.empty()) return;
+				std::vector<double> v;
+				std::stringstream ss(s);
+				std::string t;
+				while (std::getline(ss, t, ',')) v.push_back(std::stod(t));
+				if (v.size() >= 4) { m1 = v[0]; M1 = v[1]; m2 = v[2]; M2 = v[3]; }
+			};
+			parse4("NormalFAngleRanges", NormalFAngleRMin, NormalFAngleRMax, NormalFAngleRMin2, NormalFAngleRMax2);
+			parse4("NormalLAngleRanges", NormalLAngleRMin, NormalLAngleRMax, NormalLAngleRMin2, NormalLAngleRMax2);
+			parse4("NormalHAngleRanges", NormalHAngleRMin, NormalHAngleRMax, NormalHAngleRMin2, NormalHAngleRMax2);
+		}
+		Lissajous = reader->Get(title + "Lissajous", 0.0);
+
+		// --- MoveTo ---
+		MoveTo = reader->Get(title + "MoveTo", MoveTo);
+		GrowRate = reader->Get(title + "GrowRate", GrowRate);
+		AnglePerStep = reader->Get(title + "AnglePerStep", 0.0);
+
+		// --- Circle ---
+		CircleRadius = reader->Get(title + "CircleRadius", -1);
+		CircleSpeed = reader->Get(title + "CircleSpeed", 0);
+		CircleSpeedAcceleration = reader->Get(title + "CircleSpeedAcceleration", 0);
+		CircleMaxSpeed = reader->Get(title + "CircleMaxSpeed", 0);
+		CircleMinSpeed = reader->Get(title + "CircleMinSpeed", 0);
+		CircleAnglePerStep = reader->Get(title + "CircleAnglePerStep", 0.0);
+		CircleAngleAcceleration = reader->Get(title + "CircleAngleAcceleration", 0.0);
+		std::string circleRandomRadiusStr = reader->Get(title + "CircleRandomRadius", std::string{ "" });
+		ParseMinMax(circleRandomRadiusStr, CircleRandomRadiusMin, CircleRandomRadiusMax);
+		std::string circleRandomAngleStr = reader->Get(title + "CircleRandomAngle", std::string{ "" });
+		if (!circleRandomAngleStr.empty())
+		{
+			auto comma = circleRandomAngleStr.find(',');
+			if (comma != std::string::npos)
+			{
+				CircleRandomAngleMin = std::stod(circleRandomAngleStr.substr(0, comma));
+				CircleRandomAngleMax = std::stod(circleRandomAngleStr.substr(comma + 1));
+			}
+		}
+		std::string circleRandomAngleRangesStr = reader->Get(title + "CircleRandomAngleRanges", std::string{ "" });
+		if (!circleRandomAngleRangesStr.empty())
+		{
+			std::vector<double> angles;
+			std::stringstream ss(circleRandomAngleRangesStr);
+			std::string token;
+			while (std::getline(ss, token, ','))
+				angles.push_back(std::stod(token));
+			if (angles.size() >= 4)
+			{
+				CircleRandomAngleMin = angles[0];
+				CircleRandomAngleMax = angles[1];
+				CircleRandomAngleMin2 = angles[2];
+				CircleRandomAngleMax2 = angles[3];
+			}
+		}
+		CircleMaxAngle = reader->Get(title + "CircleMaxAngle", 0.0);
+		CircleMinAngle = reader->Get(title + "CircleMinAngle", 0.0);
+		CircleOrigin = reader->Get(title + "CircleOrigin", CircleOrigin);
+		AllowOriginTilt = reader->Get(title + "AllowOriginTilt", AllowOriginTilt);
+		CircleRadiusGrow = reader->Get(title + "CircleRadiusGrow", 0);
+		CircleMaxRadius = reader->Get(title + "CircleMaxRadius", 0);
+		CircleMinRadius = reader->Get(title + "CircleMinRadius", 0);
+		CircleEndOnMaxRadius = reader->Get(title + "CircleEndOnMaxRadius", false);
+		CircleEndOnMinRadius = reader->Get(title + "CircleEndOnMinRadius", false);
+
+		// --- Origin ---
+		OriginMoveTo = reader->Get(title + "Origin.MoveTo", OriginMoveTo);
+		OriginGrowRate = reader->Get(title + "Origin.GrowRate", OriginGrowRate);
+		OriginAnglePerStep = reader->Get(title + "Origin.AnglePerStep", 0.0);
+		OriginTargetFLH = reader->Get(title + "Origin.TargetFLH", OriginTargetFLH);
+		OriginLinearSpeed = reader->Get(title + "Origin.LinearSpeed", -1);
+		OriginAcceleration = reader->Get(title + "Origin.Acceleration", 0);
+		OriginMaxSpeed = reader->Get(title + "Origin.MaxSpeed", -1);
+		OriginMinSpeed = reader->Get(title + "Origin.MinSpeed", -1);
+		OriginReachTarget = reader->Get(title + "Origin.ReachTarget", false);
+		OriginSpeedEndOnReach = reader->Get(title + "Origin.SpeedEndOnReach", OriginSpeedEndOnReach);
+		OriginArcHeight = reader->Get(title + "Origin.ArcHeight", 0);
+		OriginArcPeakPercent = reader->Get(title + "Origin.ArcPeakPercent", OriginArcPeakPercent);
+		OriginArcPeakRandomPercent = reader->Get(title + "Origin.RandomArcPeakPercent", OriginArcPeakRandomPercent);
+		std::string originArcRandomHeightStr = reader->Get(title + "Origin.RandomArcHeight", std::string{ "" });
+		ParseMinMax(originArcRandomHeightStr, OriginArcRandomHeightMin, OriginArcRandomHeightMax);
+		OriginArcRotation = reader->Get(title + "Origin.ArcRotation", 0.0);
+		std::string originArcRandomRotationStr = reader->Get(title + "Origin.RandomArcRotation", std::string{ "" });
+		ParseMinMaxDouble(originArcRandomRotationStr, OriginArcRandomRotationMin, OriginArcRandomRotationMax);
+		std::string originTargetOffsetFStr = reader->Get(title + "Origin.TargetOffsetF", std::string{""});
+		ParseMinMax(originTargetOffsetFStr, OriginTargetOffsetFMin, OriginTargetOffsetFMax);
+		std::string originTargetOffsetLStr = reader->Get(title + "Origin.TargetOffsetL", std::string{""});
+		ParseMinMax(originTargetOffsetLStr, OriginTargetOffsetLMin, OriginTargetOffsetLMax);
+		std::string originTargetOffsetHStr = reader->Get(title + "Origin.TargetOffsetH", std::string{""});
+		ParseMinMax(originTargetOffsetHStr, OriginTargetOffsetHMin, OriginTargetOffsetHMax);
+		OriginCircleRadius = reader->Get(title + "Origin.CircleRadius", -1);
+		OriginCircleSpeed = reader->Get(title + "Origin.CircleSpeed", 0);
+		OriginCircleAnglePerStep = reader->Get(title + "Origin.CircleAnglePerStep", 0.0);
+		std::string originCircleRandomRadiusStr = reader->Get(title + "Origin.CircleRandomRadius", std::string{""});
+		ParseMinMax(originCircleRandomRadiusStr, OriginCircleRandomRadiusMin, OriginCircleRandomRadiusMax);
+		std::string originCircleRandomAngleStr = reader->Get(title + "Origin.CircleRandomAngle", std::string{""});
+		ParseMinMaxDouble(originCircleRandomAngleStr, OriginCircleRandomAngleMin, OriginCircleRandomAngleMax);
+		OriginCircleRadiusGrow = reader->Get(title + "Origin.CircleRadiusGrow", 0);
+		OriginCircleMaxRadius = reader->Get(title + "Origin.CircleMaxRadius", 0);
+		OriginCircleMinRadius = reader->Get(title + "Origin.CircleMinRadius", 0);
+		OriginCircleEndOnMaxRadius = reader->Get(title + "Origin.CircleEndOnMaxRadius", false);
+		OriginCircleEndOnMinRadius = reader->Get(title + "Origin.CircleEndOnMinRadius", false);
+		OriginNormalVector = reader->Get(title + "Origin.NormalVector", OriginNormalVector);
+		OriginNormalRandomF = reader->Get(title + "Origin.NormalRandomF", OriginNormalRandomF);
+		OriginNormalRandomL = reader->Get(title + "Origin.NormalRandomL", OriginNormalRandomL);
+		OriginNormalRandomH = reader->Get(title + "Origin.NormalRandomH", OriginNormalRandomH);
+		OriginNormalFAnglePerStep = reader->Get(title + "Origin.NormalFAnglePerStep", 0.0);
+		OriginNormalLAnglePerStep = reader->Get(title + "Origin.NormalLAnglePerStep", 0.0);
+		OriginNormalHAnglePerStep = reader->Get(title + "Origin.NormalHAnglePerStep", 0.0);
+		OriginAllowCircleTilt = reader->Get(title + "Origin.AllowCircleTilt", OriginAllowCircleTilt);
+		OriginCircleOffset = reader->Get(title + "Origin.CircleOrigin", OriginCircleOffset);
+		OriginAllowOriginTilt = reader->Get(title + "Origin.AllowOriginTilt", OriginAllowOriginTilt);
+		OriginOriginNoUpdate = reader->Get(title + "Origin.OriginNoUpdate", false);
+		OriginLissajous = reader->Get(title + "Origin.Lissajous", 0.0);
+		std::string originOriginStr = reader->Get(title + "Origin.Origin", std::string{ "Self" });
+		if (originOriginStr == "Launcher") OriginOrigin = VectorOrigin::Launcher;
+		else if (originOriginStr == "Target") OriginOrigin = VectorOrigin::Target;
+		else if (originOriginStr == "Source") OriginOrigin = VectorOrigin::Source;
+		else OriginOrigin = VectorOrigin::Self;
+		OriginOriginFLH = reader->Get(title + "Origin.OriginFLH", OriginOriginFLH);
+
+		// --- Speed / ReachTarget ---
+		TargetFLH = reader->Get(title + "TargetFLH", TargetFLH);
+		std::string targetOffsetFStr = reader->Get(title + "TargetOffsetF", std::string{ "" });
+		std::string targetOffsetLStr = reader->Get(title + "TargetOffsetL", std::string{ "" });
+		std::string targetOffsetHStr = reader->Get(title + "TargetOffsetH", std::string{ "" });
+		ParseMinMax(targetOffsetFStr, TargetOffsetFMin, TargetOffsetFMax);
+		ParseMinMax(targetOffsetLStr, TargetOffsetLMin, TargetOffsetLMax);
+		ParseMinMax(targetOffsetHStr, TargetOffsetHMin, TargetOffsetHMax);
+		{
+			// 四参数版：min1,max1,min2,max2。前两位覆盖区间1（Min/Max），后两位写区间2（Min2/Max2）
+			// 双区间全无效时保留两参数值（回退语义）
+			auto parse4i = [&](const char* key, int& m1, int& M1, int& m2, int& M2) {
+				auto s = reader->Get(title + key, std::string{ "" });
+				if (s.empty()) return;
+				std::vector<int> v;
+				std::stringstream ss(s);
+				std::string t;
+				while (std::getline(ss, t, ',')) v.push_back(std::stoi(t));
+				if (v.size() >= 4 && (v[0] < v[1] || v[2] < v[3]))
+				{
+					m1 = v[0]; M1 = v[1];
+					m2 = v[2]; M2 = v[3];
+				}
+			};
+			parse4i("TargetOffsetFRanges", TargetOffsetFMin, TargetOffsetFMax, TargetOffsetFMin2, TargetOffsetFMax2);
+			parse4i("TargetOffsetLRanges", TargetOffsetLMin, TargetOffsetLMax, TargetOffsetLMin2, TargetOffsetLMax2);
+			parse4i("TargetOffsetHRanges", TargetOffsetHMin, TargetOffsetHMax, TargetOffsetHMin2, TargetOffsetHMax2);
+			parse4i("TargetOffsetAngles", TargetOffsetAngleMin, TargetOffsetAngleMax, TargetOffsetAngleMin2, TargetOffsetAngleMax2);
+			parse4i("TargetOffsetRadiusRanges", TargetOffsetRadiusMin, TargetOffsetRadiusMax, TargetOffsetRadiusMin2, TargetOffsetRadiusMax2);
+		}
+		std::string targetOffsetRadiusStr = reader->Get(title + "TargetOffsetRadius", std::string{ "" });
+		ParseMinMax(targetOffsetRadiusStr, TargetOffsetRadiusMin, TargetOffsetRadiusMax);
+		TargetOffsetSphere = reader->Get(title + "TargetOffsetSphere", TargetOffsetSphere);
+		ReachTarget = reader->Get(title + "ReachTarget", ReachTarget);
+		ReachTargetEarlyEnd = reader->Get(title + "ReachTargetEarlyEnd", ReachTargetEarlyEnd);
+		ArcHeight = reader->Get(title + "ArcHeight", 0);
+		ArcPeakPercent = reader->Get(title + "ArcPeakPercent", ArcPeakPercent);
+		ArcPeakRandomPercent = reader->Get(title + "RandomArcPeakPercent", ArcPeakRandomPercent);
+		std::string arcRandomHeightStr = reader->Get(title + "RandomArcHeight", std::string{ "" });
+		ParseMinMax(arcRandomHeightStr, ArcRandomHeightMin, ArcRandomHeightMax);
+		ArcRotation = reader->Get(title + "ArcRotation", 0.0);
+		std::string arcRandomRotationStr = reader->Get(title + "RandomArcRotation", std::string{ "" });
+		ParseMinMaxDouble(arcRandomRotationStr, ArcRandomRotationMin, ArcRandomRotationMax);
+		AllowFallingDestroy = reader->Get(title + "AllowFallingDestroy", AllowFallingDestroy);
+		FallingDestroyHeight = reader->Get(title + "FallingDestroyHeight", FallingDestroyHeight);
+
+		// --- 速度 ---
+		LinearSpeed = reader->Get(title + "LinearSpeed", -1);
+		std::string randomSpeedStr = reader->Get(title + "RandomSpeed", std::string{ "" });
+		ParseMinMax(randomSpeedStr, RandomSpeedMin, RandomSpeedMax);
+		MaxSpeed = reader->Get(title + "MaxSpeed", -1);
+		MinSpeed = reader->Get(title + "MinSpeed", -1);
+		Acceleration = reader->Get(title + "Acceleration", Acceleration);
+		SpeedEndOnReach = reader->Get(title + "SpeedEndOnReach", SpeedEndOnReach);
+
+		Enable = !MoveTo.IsEmpty() || Freeze || ReachTarget
+			|| (LinearSpeed >= 0)
+			|| (CircleRadius > 0) || (CircleSpeed != 0) || (CircleAnglePerStep > 0.0)
+			|| (CircleRandomRadiusMax > CircleRandomRadiusMin)
+			|| (CircleRandomAngleMax > CircleRandomAngleMin)
+			|| (CircleRandomAngleMax2 > CircleRandomAngleMin2);
+	}
+
+	static void ParseMinMaxDouble(const std::string& str, double& min, double& max)
+	{
+		if (str.empty()) return;
+		size_t commaPos = str.find(',');
+		if (commaPos != std::string::npos)
+		{
+			min = std::stod(str.substr(0, commaPos));
+			max = std::stod(str.substr(commaPos + 1));
+		}
+		else
+		{
+			min = std::stod(str);
+			max = min;
+		}
+	}
+
+private:
+	static void ParseMinMax(const std::string& str, int& min, int& max)
+	{
+		if (str.empty()) return;
+		size_t commaPos = str.find(',');
+		if (commaPos != std::string::npos)
+		{
+			min = std::stoi(str.substr(0, commaPos));
+			max = std::stoi(str.substr(commaPos + 1));
+		}
+		else
+		{
+			min = std::stoi(str);
+			max = min;
+		}
+	}
+
+#pragma region save/load
+	template <typename T>
+	bool Serialize(T& stream)
+	{
+		stream
+			.Process(this->TimeStep).Process(this->DisabledFrames).Process(this->SyncFacing).Process(this->OriginIsOnWorld).Process(this->OriginIsOnBody)
+			.Process(this->Origin)
+			.Process(this->OriginFLH)
+			.Process(this->OriginNoUpdate)
+			.Process(this->Force)
+			.Process(this->Freeze)
+			.Process(this->AllowCircleTilt)
+			.Process(this->NormalVector)
+			.Process(this->NormalRandomF)
+			.Process(this->NormalRandomL)
+			.Process(this->NormalRandomH)
+			.Process(this->NormalFAnglePerStep)
+			.Process(this->NormalLAnglePerStep)
+			.Process(this->NormalHAnglePerStep)
+			.Process(this->NormalFAngleRMin).Process(this->NormalFAngleRMax)
+			.Process(this->NormalFAngleRMin2).Process(this->NormalFAngleRMax2)
+			.Process(this->NormalLAngleRMin).Process(this->NormalLAngleRMax)
+			.Process(this->NormalLAngleRMin2).Process(this->NormalLAngleRMax2)
+			.Process(this->NormalHAngleRMin).Process(this->NormalHAngleRMax)
+			.Process(this->NormalHAngleRMin2).Process(this->NormalHAngleRMax2)
+			.Process(this->Lissajous)
+
+			.Process(this->MoveTo)
+			.Process(this->GrowRate)
+			.Process(this->AnglePerStep)
+			.Process(this->CircleRadius)
+			.Process(this->CircleSpeed)
+			.Process(this->CircleSpeedAcceleration)
+			.Process(this->CircleMaxSpeed)
+			.Process(this->CircleMinSpeed)
+			.Process(this->CircleAnglePerStep)
+			.Process(this->CircleAngleAcceleration)
+			.Process(this->CircleMaxAngle)
+			.Process(this->CircleMinAngle)
+			.Process(this->CircleOrigin)
+			.Process(this->AllowOriginTilt)
+			.Process(this->CircleRandomRadiusMin)
+			.Process(this->CircleRandomRadiusMax)
+			.Process(this->CircleRandomAngleMin)
+			.Process(this->CircleRandomAngleMax)
+			.Process(this->CircleRandomAngleMin2)
+			.Process(this->CircleRandomAngleMax2)
+			.Process(this->CircleRadiusGrow)
+			.Process(this->CircleMaxRadius)
+			.Process(this->CircleMinRadius)
+			.Process(this->CircleEndOnMaxRadius)
+			.Process(this->CircleEndOnMinRadius)
+			.Process(this->OriginMoveTo).Process(this->OriginGrowRate)
+			.Process(this->OriginAnglePerStep).Process(this->OriginTargetFLH)
+			.Process(this->OriginLinearSpeed).Process(this->OriginReachTarget)
+			.Process(this->OriginSpeedEndOnReach)
+			.Process(this->OriginArcHeight)
+			.Process(this->OriginArcPeakPercent)
+			.Process(this->OriginArcPeakRandomPercent)
+			.Process(this->OriginArcRandomHeightMin)
+			.Process(this->OriginArcRandomHeightMax)
+			.Process(this->OriginArcRotation)
+			.Process(this->OriginArcRandomRotationMin)
+			.Process(this->OriginArcRandomRotationMax)
+			.Process(this->OriginTargetOffsetFMin).Process(this->OriginTargetOffsetFMax)
+			.Process(this->OriginTargetOffsetLMin).Process(this->OriginTargetOffsetLMax)
+			.Process(this->OriginTargetOffsetHMin).Process(this->OriginTargetOffsetHMax)
+			.Process(this->OriginCircleRadius).Process(this->OriginCircleSpeed)
+			.Process(this->OriginCircleAnglePerStep)
+			.Process(this->OriginCircleRandomRadiusMin).Process(this->OriginCircleRandomRadiusMax)
+			.Process(this->OriginCircleRandomAngleMin).Process(this->OriginCircleRandomAngleMax)
+			.Process(this->OriginCircleRadiusGrow).Process(this->OriginCircleMaxRadius)
+			.Process(this->OriginCircleMinRadius)
+			.Process(this->OriginCircleEndOnMaxRadius).Process(this->OriginCircleEndOnMinRadius)
+			.Process(this->OriginNormalVector)
+			.Process(this->OriginNormalRandomF).Process(this->OriginNormalRandomL)
+			.Process(this->OriginNormalRandomH)
+			.Process(this->OriginNormalFAnglePerStep).Process(this->OriginNormalLAnglePerStep)
+			.Process(this->OriginNormalHAnglePerStep)
+			.Process(this->OriginNormalFAngleRMin).Process(this->OriginNormalFAngleRMax)
+			.Process(this->OriginNormalFAngleRMin2).Process(this->OriginNormalFAngleRMax2)
+			.Process(this->OriginNormalLAngleRMin).Process(this->OriginNormalLAngleRMax)
+			.Process(this->OriginNormalLAngleRMin2).Process(this->OriginNormalLAngleRMax2)
+			.Process(this->OriginNormalHAngleRMin).Process(this->OriginNormalHAngleRMax)
+			.Process(this->OriginNormalHAngleRMin2).Process(this->OriginNormalHAngleRMax2)
+			.Process(this->OriginAllowCircleTilt).Process(this->OriginCircleOffset)
+			.Process(this->OriginAllowOriginTilt).Process(this->OriginOriginNoUpdate)
+			.Process(this->OriginLissajous)
+			.Process(this->OriginOrigin)
+			.Process(this->OriginOriginFLH)
+
+			.Process(this->TargetFLH)
+			.Process(this->TargetOffsetFMin)
+			.Process(this->TargetOffsetFMax)
+			.Process(this->TargetOffsetLMin)
+			.Process(this->TargetOffsetLMax)
+			.Process(this->TargetOffsetHMin)
+			.Process(this->TargetOffsetHMax)
+			.Process(this->TargetOffsetFMin2)
+			.Process(this->TargetOffsetFMax2)
+			.Process(this->TargetOffsetLMin2)
+			.Process(this->TargetOffsetLMax2)
+			.Process(this->TargetOffsetHMin2)
+			.Process(this->TargetOffsetHMax2)
+			.Process(this->TargetOffsetRadiusMin)
+			.Process(this->TargetOffsetRadiusMax)
+			.Process(this->TargetOffsetRadiusMin2)
+			.Process(this->TargetOffsetRadiusMax2)
+			.Process(this->TargetOffsetSphere)
+			.Process(this->TargetOffsetAngleMin)
+			.Process(this->TargetOffsetAngleMax)
+			.Process(this->TargetOffsetAngleMin2)
+			.Process(this->TargetOffsetAngleMax2)
+			.Process(this->ReachTarget)
+			.Process(this->ReachTargetEarlyEnd)
+			.Process(this->ArcHeight)
+			.Process(this->ArcPeakPercent)
+			.Process(this->ArcPeakRandomPercent)
+			.Process(this->ArcRandomHeightMin)
+			.Process(this->ArcRandomHeightMax)
+			.Process(this->ArcRotation)
+			.Process(this->ArcRandomRotationMin)
+			.Process(this->ArcRandomRotationMax)
+			.Process(this->AllowFallingDestroy)
+			.Process(this->FallingDestroyHeight)
+
+			.Process(this->LinearSpeed)
+			.Process(this->RandomSpeedMin)
+			.Process(this->RandomSpeedMax)
+			.Process(this->MaxSpeed)
+			.Process(this->MinSpeed)
+			.Process(this->Acceleration)
+			.Process(this->SpeedEndOnReach);
+		return stream.Success();
+	};
+
+	virtual bool Load(ExStreamReader& stream, bool registerForChange) override
+	{
+		EffectData::Load(stream, registerForChange);
+		return this->Serialize(stream);
+	}
+	virtual bool Save(ExStreamWriter& stream) const override
+	{
+		EffectData::Save(stream);
+		return const_cast<VectorData*>(this)->Serialize(stream);
+	}
+#pragma endregion
+};

--- a/src/Ext/EffectType/Effect/VectorDataReVibed.h
+++ b/src/Ext/EffectType/Effect/VectorDataReVibed.h
@@ -48,6 +48,9 @@ public:
 	bool Force = true;                  // yes=SetLocation 硬控，默认所有 Vector 模式 Force
 	bool Freeze = false;
 	bool AllowCircleTilt = true;         // yes=允许圆面使用 NormalVector 或地形倾斜
+	bool IsOnOrigin = false;             // （INI: Vector.OriginIsOnVectorOrigin）FLH 参考系（F 轴）来源：yes=Origin 单位自身朝向，no=Origin→弹体连线
+										 // 默认按 Origin 类型推导（Launcher/Self→yes，Target/Source→no），与旧版行为一致
+	bool IsNormalOnOrigin = true;        // 圆面法向量：yes（默认）=每帧跟随 Origin 单位自身朝向转动，no=世界固定
 
 	// ========================================================================
 	// NormalVector 圆面法线
@@ -150,6 +153,7 @@ public:
 	double OriginNormalHAngleRMin = 0, OriginNormalHAngleRMax = 0, OriginNormalHAngleRMin2 = 0, OriginNormalHAngleRMax2 = 0;
 	// 圆心通用
 	bool OriginAllowCircleTilt = true;    // yes=大圆面跟随目标倾斜（Origin=Target 时有效）
+	bool OriginIsNormalOnOrigin = true;   // 大圆法向量：yes（默认）=每帧跟随 OriginOrigin 单位自身朝向转动，no=世界固定
 	CoordStruct OriginCircleOffset{};     // 圆心原点偏移（世界坐标）
 	bool OriginAllowOriginTilt = true;
 	bool OriginOriginNoUpdate = false;   // yes=圆心基座冻结在初始位置，不随目标移动
@@ -181,6 +185,7 @@ public:
 	int TargetOffsetRadiusMin2 = 0;  // 四参数版（TargetOffsetRadiusRanges）区间2，区间1复用 Min/Max
 	int TargetOffsetRadiusMax2 = 0;
 	bool TargetOffsetSphere = false;   // yes=球面全向（含H），no=XY圆环+H用TargetOffsetH
+	CoordStruct TargetOffsetNormal{};  // 圆环法向量（FLH），非空时 TargetOffsetSphere=no 的落点在倾斜圆面上（法向量定义圆面）
 	// 角度限制（TargetOffsetAngles，仅圆环模式）：双区间，0度=目标点指向抛射体（近交点）
 	int TargetOffsetAngleMin = 0;
 	int TargetOffsetAngleMax = 0;
@@ -249,6 +254,9 @@ public:
 		Force = reader->Get(title + "Force", Force);
 		Freeze = reader->Get(title + "Freeze", Freeze);
 		AllowCircleTilt = reader->Get(title + "AllowCircleTilt", AllowCircleTilt);
+		// 默认按 Origin 类型推导旧版行为：Launcher/Self=单位自身朝向(yes)，Target/Source=连线(no)
+		IsOnOrigin = reader->Get(title + "OriginIsOnVectorOrigin", Origin == VectorOrigin::Launcher || Origin == VectorOrigin::Self);
+		IsNormalOnOrigin = reader->Get(title + "IsNormalOnOrigin", true); // 默认跟随 Origin 单位，no 才世界固定
 		NormalVector = reader->Get(title + "NormalVector", NormalVector);
 		NormalRandomF = reader->Get(title + "NormalRandomF", NormalRandomF);
 		NormalRandomL = reader->Get(title + "NormalRandomL", NormalRandomL);
@@ -368,6 +376,7 @@ public:
 		OriginNormalLAnglePerStep = reader->Get(title + "Origin.NormalLAnglePerStep", 0.0);
 		OriginNormalHAnglePerStep = reader->Get(title + "Origin.NormalHAnglePerStep", 0.0);
 		OriginAllowCircleTilt = reader->Get(title + "Origin.AllowCircleTilt", OriginAllowCircleTilt);
+		OriginIsNormalOnOrigin = reader->Get(title + "Origin.IsNormalOnOrigin", true); // 默认跟随 OriginOrigin 单位，no 才世界固定
 		OriginCircleOffset = reader->Get(title + "Origin.CircleOrigin", OriginCircleOffset);
 		OriginAllowOriginTilt = reader->Get(title + "Origin.AllowOriginTilt", OriginAllowOriginTilt);
 		OriginOriginNoUpdate = reader->Get(title + "Origin.OriginNoUpdate", false);
@@ -412,6 +421,7 @@ public:
 		std::string targetOffsetRadiusStr = reader->Get(title + "TargetOffsetRadius", std::string{ "" });
 		ParseMinMax(targetOffsetRadiusStr, TargetOffsetRadiusMin, TargetOffsetRadiusMax);
 		TargetOffsetSphere = reader->Get(title + "TargetOffsetSphere", TargetOffsetSphere);
+		TargetOffsetNormal = reader->Get(title + "TargetOffsetNormal", TargetOffsetNormal);
 		ReachTarget = reader->Get(title + "ReachTarget", ReachTarget);
 		ReachTargetEarlyEnd = reader->Get(title + "ReachTargetEarlyEnd", ReachTargetEarlyEnd);
 		ArcHeight = reader->Get(title + "ArcHeight", 0);
@@ -487,6 +497,8 @@ private:
 			.Process(this->Force)
 			.Process(this->Freeze)
 			.Process(this->AllowCircleTilt)
+			.Process(this->IsOnOrigin)
+			.Process(this->IsNormalOnOrigin)
 			.Process(this->NormalVector)
 			.Process(this->NormalRandomF)
 			.Process(this->NormalRandomL)
@@ -560,7 +572,7 @@ private:
 			.Process(this->OriginNormalLAngleRMin2).Process(this->OriginNormalLAngleRMax2)
 			.Process(this->OriginNormalHAngleRMin).Process(this->OriginNormalHAngleRMax)
 			.Process(this->OriginNormalHAngleRMin2).Process(this->OriginNormalHAngleRMax2)
-			.Process(this->OriginAllowCircleTilt).Process(this->OriginCircleOffset)
+			.Process(this->OriginAllowCircleTilt).Process(this->OriginIsNormalOnOrigin).Process(this->OriginCircleOffset)
 			.Process(this->OriginAllowOriginTilt).Process(this->OriginOriginNoUpdate)
 			.Process(this->OriginLissajous)
 			.Process(this->OriginOrigin)
@@ -584,6 +596,7 @@ private:
 			.Process(this->TargetOffsetRadiusMin2)
 			.Process(this->TargetOffsetRadiusMax2)
 			.Process(this->TargetOffsetSphere)
+			.Process(this->TargetOffsetNormal)
 			.Process(this->TargetOffsetAngleMin)
 			.Process(this->TargetOffsetAngleMax)
 			.Process(this->TargetOffsetAngleMin2)

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -35,9 +35,73 @@ void VectorEffect::OnStart()
 	_vectorAcquireZ = _initialLocation.Z;  // Circle 圆心高度基准：获取 Vector 时的 Z
 	_totalDuration = AE->AEData.GetDuration() / _effectiveTimeStep;
 
-	_randomTargetOffset.X = Random::RandomRanged(Data->TargetOffsetFMin, Data->TargetOffsetFMax);
-	_randomTargetOffset.Y = Random::RandomRanged(Data->TargetOffsetLMin, Data->TargetOffsetLMax);
-	_randomTargetOffset.Z = Random::RandomRanged(Data->TargetOffsetHMin, Data->TargetOffsetHMax);
+	// TargetOffset 随机偏移
+	if (Data->TargetOffsetRadiusMin < Data->TargetOffsetRadiusMax)
+	{
+		// 半径模式：全向随机落点（与 F/L/H 互斥）
+		double radius = (Data->TargetOffsetRadiusMin2 < Data->TargetOffsetRadiusMax2 && Random::RandomRanged(0, 1))
+			? Random::RandomRanged(Data->TargetOffsetRadiusMin2, Data->TargetOffsetRadiusMax2)
+			: Random::RandomRanged(Data->TargetOffsetRadiusMin, Data->TargetOffsetRadiusMax);
+		if (Data->TargetOffsetSphere)
+		{
+			// 球面均匀分布：z=2u-1 面积均匀 + 经度 2πv，避免极区聚集
+			double u = Random::RandomDouble() * 2.0 - 1.0;
+			double phi = Random::RandomDouble() * 2.0 * M_PI;
+			double rXY = radius * std::sqrt(1.0 - u * u);
+			_randomTargetOffset.X = static_cast<int>(rXY * std::cos(phi));
+			_randomTargetOffset.Y = static_cast<int>(rXY * std::sin(phi));
+			_randomTargetOffset.Z = static_cast<int>(radius * u);
+		}
+		else
+		{
+			// XY 圆环：角度默认全向，TargetOffsetAngles 限制时按区间加权均匀
+			// FLH 系角 = -90°-deg：消费端 GetFLHAbsoluteOffset 世界角 = -(mainFacingDir + flhAngle)，
+			// Origin=Target 时 mainFacingDir=近交点方向，世界落点角 = 近交点角 + deg，以近交点对称
+			double flhAngle;
+			bool hasAngleRange = (Data->TargetOffsetAngleMin < Data->TargetOffsetAngleMax)
+				|| (Data->TargetOffsetAngleMin2 < Data->TargetOffsetAngleMax2);
+			if (hasAngleRange)
+			{
+				// 区间加权均匀：u 落在总长度内，映射到对应区间
+				double len1 = Data->TargetOffsetAngleMax - Data->TargetOffsetAngleMin;
+				double len2 = Data->TargetOffsetAngleMax2 - Data->TargetOffsetAngleMin2;
+				double total = (len1 > 0 ? len1 : 0.0) + (len2 > 0 ? len2 : 0.0);
+				double u = Random::RandomDouble() * total;
+				double deg;
+				if (len1 > 0 && u < len1)
+					deg = Data->TargetOffsetAngleMin + u;
+				else
+					deg = Data->TargetOffsetAngleMin2 + (u - (len1 > 0 ? len1 : 0.0));
+				flhAngle = Math::deg2rad(-90.0 - deg);
+			}
+			else
+			{
+				flhAngle = Random::RandomDouble() * 2.0 * M_PI;  // 无角度限制：全向
+			}
+			_randomTargetOffset.X = static_cast<int>(radius * std::cos(flhAngle));
+			_randomTargetOffset.Y = static_cast<int>(radius * std::sin(flhAngle));
+			_randomTargetOffset.Z = (Data->TargetOffsetHMin2 < Data->TargetOffsetHMax2 && Random::RandomRanged(0, 1))
+				? Random::RandomRanged(Data->TargetOffsetHMin2, Data->TargetOffsetHMax2)
+				: (Data->TargetOffsetHMin < Data->TargetOffsetHMax
+					? Random::RandomRanged(Data->TargetOffsetHMin, Data->TargetOffsetHMax) : 0);
+		}
+	}
+	else
+	{
+		// F/L/H 模式：区间2有效且50%取区间2，否则区间1（无效给0）
+		_randomTargetOffset.X = (Data->TargetOffsetFMin2 < Data->TargetOffsetFMax2 && Random::RandomRanged(0, 1))
+			? Random::RandomRanged(Data->TargetOffsetFMin2, Data->TargetOffsetFMax2)
+			: (Data->TargetOffsetFMin < Data->TargetOffsetFMax
+				? Random::RandomRanged(Data->TargetOffsetFMin, Data->TargetOffsetFMax) : 0);
+		_randomTargetOffset.Y = (Data->TargetOffsetLMin2 < Data->TargetOffsetLMax2 && Random::RandomRanged(0, 1))
+			? Random::RandomRanged(Data->TargetOffsetLMin2, Data->TargetOffsetLMax2)
+			: (Data->TargetOffsetLMin < Data->TargetOffsetLMax
+				? Random::RandomRanged(Data->TargetOffsetLMin, Data->TargetOffsetLMax) : 0);
+		_randomTargetOffset.Z = (Data->TargetOffsetHMin2 < Data->TargetOffsetHMax2 && Random::RandomRanged(0, 1))
+			? Random::RandomRanged(Data->TargetOffsetHMin2, Data->TargetOffsetHMax2)
+			: (Data->TargetOffsetHMin < Data->TargetOffsetHMax
+				? Random::RandomRanged(Data->TargetOffsetHMin, Data->TargetOffsetHMax) : 0);
+	}
 
 	// 弧面旋转角
 	_arcRotation = Data->ArcRotation;

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -25,9 +25,11 @@ void VectorEffect::OnStart()
 	_active = true;
 	_elapsedFrames = 0;
 	_moveFrame = 0;
+	_movementFrames = 0;
 	_currentAngle = 0.0;
-	_prevCirclePos = pObject->GetCoords();
+	// _prevCirclePos = pObject->GetCoords();  // [DEAD] 从未读取
 	_effectiveTimeStep = Data->TimeStep;
+	_prevCircleCenter = pObject->GetCoords();
 
 	_initialLocation = pObject->GetCoords();
 	_totalDuration = AE->GetDuration() / _effectiveTimeStep;
@@ -45,11 +47,17 @@ void VectorEffect::OnStart()
 	if (Data->ArcRandomHeightMax > Data->ArcRandomHeightMin)
 		_arcHeight = Random::RandomRanged(Data->ArcRandomHeightMin, Data->ArcRandomHeightMax);
 
+	_arcPeakPercent = Data->ArcPeakPercent / 100.0;
+	if (Data->ArcPeakRandomPercent.X < Data->ArcPeakRandomPercent.Y)
+		_arcPeakPercent = Random::RandomRanged(Data->ArcPeakRandomPercent.X, Data->ArcPeakRandomPercent.Y) / 100.0;
+	if (_arcPeakPercent <= 0.0) _arcPeakPercent = 0.5;
+	if (_arcPeakPercent >= 1.0) _arcPeakPercent = 0.5;
+
 	// --- 初始速度 ---
 	_currentSpeed = 0.0;
-	if (Data->InitialSpeed >= 0)
+	if (Data->LinearSpeed >= 0)
 	{
-		_currentSpeed = static_cast<double>(Data->InitialSpeed);
+		_currentSpeed = static_cast<double>(Data->LinearSpeed);
 	}
 	else if (pTechno)
 	{
@@ -308,13 +316,13 @@ VectorResult VectorEffect::GetVectorResult()
 	}
 	_movementFrames++;
 
-	// 成熟机制，别乱动：法线旋转每运动帧累加角速度
-	if (ShouldMoveThisFrame())
-	{
+	// [REDUNDANT] 此处 ShouldMoveThisFrame() 必定为 true（310行已 return）
+	// if (ShouldMoveThisFrame())
+	// {
 		_normalRotF += _normalStepF;
 		_normalRotL += _normalStepL;
 		_normalRotH += _normalStepH;
-	}
+	// }
 
 	CoordStruct currentPos = pObject->GetCoords();
 
@@ -447,7 +455,7 @@ VectorResult VectorEffect::GetVectorResult()
 	// ========================================================================
 	// 成熟机制，别乱动 — 模式 C: Circle（独立圆周，圆心=Origin，三选二参数）
 	// ========================================================================
-	bool hasCircle = Data->CircleRadius > 0 || Data->CircleSpeed != 0 || Data->CircleAnglePerStep > 0.0
+	bool hasCircle = Data->CircleRadius > 0 || Data->CircleAnglePerStep > 0.0
 		|| (Data->CircleRandomRadiusMax > Data->CircleRandomRadiusMin)
 		|| (Data->CircleRandomAngleMax > Data->CircleRandomAngleMin);
 	if (hasCircle)
@@ -463,7 +471,17 @@ VectorResult VectorEffect::GetVectorResult()
 
 		// 动态线速：首帧初始化，每帧叠加加速度
 		if (_elapsedFrames == 0)
+		{
 			_currentCircleSpeed = static_cast<double>(Data->CircleSpeed);
+			// 无速度参数时，兜底取抛射体/单位自身速度
+			if (_currentCircleSpeed <= 0.0)
+			{
+				if (pBullet)
+					_currentCircleSpeed = pBullet->Speed;
+				else if (pTechno)
+					_currentCircleSpeed = pTechno->GetTechnoType()->Speed;
+			}
+		}
 		_currentCircleSpeed += Data->CircleSpeedAcceleration;
 		if (Data->CircleMaxSpeed != 0 && _currentCircleSpeed > Data->CircleMaxSpeed)
 			_currentCircleSpeed = static_cast<double>(Data->CircleMaxSpeed);
@@ -491,9 +509,10 @@ VectorResult VectorEffect::GetVectorResult()
 		double speed = _currentCircleSpeed;
 		double angleStep = _currentCircleAngle;
 
-		if (speed <= 0.0 && angleStep > 0.0)
+		// 三选二：半径 + 角速度优先，两者都有时速率由角速度推算（忽略显式 CircleSpeed）
+		if (angleStep > 0.0)
 			speed = calcRadius * Math::deg2rad(angleStep);
-		else if (angleStep <= 0.0 && speed > 0.0)
+		else if (speed > 0.0)
 			angleStep = Math::rad2deg(speed / calcRadius);
 
 		// 圆心 = Origin + CircleOrigin 偏移（世界坐标系）
@@ -508,7 +527,7 @@ VectorResult VectorEffect::GetVectorResult()
 
 		// 圆心移动：Vector.Origin.* 系统
 		if (!Data->OriginMoveTo.IsEmpty() || !Data->OriginTargetFLH.IsEmpty()
-			|| Data->OriginCircleRadius >= 0 || Data->OriginCircleSpeed != 0 || Data->OriginCircleAnglePerStep != 0)
+			|| Data->OriginCircleRadius >= 0 || Data->OriginCircleSpeed != 0 || Data->OriginLinearSpeed >= 0 || Data->OriginCircleAnglePerStep != 0)
 		{
 			// 基座：默认 originPos，OriginOrigin 可替换为独立参考系
 			CoordStruct baseCenter = originPos;
@@ -559,7 +578,7 @@ VectorResult VectorEffect::GetVectorResult()
 				_originOffset = circleCenter - baseCenter;
 				// Circle 初始化
 				_originCircleRadius = Data->OriginCircleRadius;
-				_originCircleSpeed = Data->OriginCircleSpeed;
+				_originCircleSpeed = Data->OriginLinearSpeed >= 0 ? Data->OriginLinearSpeed : Data->OriginCircleSpeed;
 				_originCircleAngle = 0.0; // 初始相位
 				// 随机
 				if (Data->OriginCircleRandomRadiusMax > Data->OriginCircleRandomRadiusMin)
@@ -587,7 +606,7 @@ VectorResult VectorEffect::GetVectorResult()
 				_originNormalStepL = res(Data->OriginNormalLAnglePerStep, Data->OriginNormalLAngleRMin, Data->OriginNormalLAngleRMax, Data->OriginNormalLAngleRMin2, Data->OriginNormalLAngleRMax2);
 				_originNormalStepH = res(Data->OriginNormalHAnglePerStep, Data->OriginNormalHAngleRMin, Data->OriginNormalHAngleRMax, Data->OriginNormalHAngleRMin2, Data->OriginNormalHAngleRMax2);
 				if (!Data->OriginNormalVector.IsEmpty() && !_originCircleRadius)
-					_originCircleRadius = effectiveFacing > -1 ? 0 : -1;
+					_originCircleRadius = -1;  // 有 NormalVector 但无显式半径，自动取当前距离
 				// 无 NormalVector 时从 Origin 参考系取 facing
 				if (Data->OriginNormalVector.IsEmpty())
 				{
@@ -643,7 +662,7 @@ VectorResult VectorEffect::GetVectorResult()
 			{
 				// Speed / ReachTarget
 				if (_originElapsed == 0)
-					_originSpeed = Data->OriginInitialSpeed >= 0 ? Data->OriginInitialSpeed : (pTechno ? pTechno->GetTechnoType()->Speed : 40.0);
+					_originSpeed = Data->OriginLinearSpeed >= 0 ? Data->OriginLinearSpeed : (pTechno ? pTechno->GetTechnoType()->Speed : 40.0);
 
 				CoordStruct targetWorld = GetFLHAbsoluteCoords(baseCenter, Data->OriginTargetFLH + _originTargetOffset, oFacingDir); // 官方API，不得修改
 				if (Data->OriginReachTarget)
@@ -680,7 +699,25 @@ VectorResult VectorEffect::GetVectorResult()
 					int dx = targetWorld.X - originCenter.X, dy = targetWorld.Y - originCenter.Y, dz = targetWorld.Z - originCenter.Z;
 					double dist = std::sqrt((double)dx*dx + dy*dy + dz*dz);
 					if (dist < 1.0) disp = {};
+					else if (Data->OriginSpeedEndOnReach && _originSpeed >= dist)
+					{
+						disp.X = dx; disp.Y = dy; disp.Z = dz;
+						Deactivate();
+					}
 					else { double s = _originSpeed / dist; disp.X = (int)(dx*s); disp.Y = (int)(dy*s); disp.Z = (int)(dz*s); }
+
+					// 弧高增量叠加（简化抛物线，与 OriginReachTarget 一致）
+					if (Data->OriginArcHeight != 0 && dist >= 1.0)
+					{
+						if (_originArcTotalDist < 0.0)
+							_originArcTotalDist = dist;
+						double t = (_originArcTotalDist > 1e-6) ? 1.0 - dist / _originArcTotalDist : 0.0;
+						if (t < 0.0) t = 0.0; else if (t > 1.0) t = 1.0;
+						double arcThis = 4.0 * Data->OriginArcHeight * t * (1.0 - t);
+						double arcDelta = arcThis - _originPrevArcOffset;
+						_originPrevArcOffset = arcThis;
+						disp.Z += static_cast<int>(arcDelta);
+					}
 				}
 			}
 			else // Circle 模式
@@ -691,8 +728,8 @@ VectorResult VectorEffect::GetVectorResult()
 				if (Data->OriginCircleMinRadius > 0 && tr < Data->OriginCircleMinRadius) tr = Data->OriginCircleMinRadius;
 				// 角步长：优先线速度/半径推算，否则用固定角速度
 				double angleStep = Data->OriginCircleAnglePerStep;
-				if (Data->OriginCircleSpeed != 0 && tr > 0)
-					angleStep = Math::rad2deg(Data->OriginCircleSpeed / tr);
+				if (_originCircleSpeed != 0 && tr > 0)
+					angleStep = Math::rad2deg(_originCircleSpeed / tr);
 				// Lissajous=yes: 累积大角旋转（增减边震荡），no: 每帧仅增量旋转（平滑行星）
 				_originCircleAngle += angleStep;
 				double r = Data->OriginLissajous ? Math::deg2rad(_originCircleAngle) : Math::deg2rad(angleStep);
@@ -726,12 +763,12 @@ VectorResult VectorEffect::GetVectorResult()
 		}
 
 	// 圆心位移叠加：Circle 模式追踪圆心→调整 currentPos
-	CoordStruct centerDelta;
+	CoordStruct centerDelta{ 0, 0, 0 };  // 初始化避免 C4701 警告
 	bool useCenterTracking = false;
 	if (_prevCircleCenter.X || _prevCircleCenter.Y || _prevCircleCenter.Z)
 	{
 		centerDelta = circleCenter - _prevCircleCenter;
-		if (!Data->OriginLissajous && (Data->OriginCircleRadius >= 0 || Data->OriginCircleSpeed != 0 || Data->OriginCircleAnglePerStep != 0.0))
+		if (!Data->OriginLissajous && (Data->OriginCircleRadius >= 0 || Data->OriginCircleSpeed != 0 || Data->OriginLinearSpeed >= 0 || Data->OriginCircleAnglePerStep != 0.0))
 			useCenterTracking = true;
 	}
 	_prevCircleCenter = circleCenter;
@@ -948,23 +985,23 @@ VectorResult VectorEffect::GetVectorResult()
 			resultDisp.Y = static_cast<int>(dirVec.Y / dirLen * adjustedSpeed);
 			resultDisp.Z = static_cast<int>(dirVec.Z / dirLen * adjustedSpeed);
 
-			// 抛物线弧高（支持 ArcRotation 旋转弧面）
+			// 抛物线弧高（基于初始位置，支持 ArcPeakPercent / ArcRotation）
 			if (_arcHeight != 0)
 			{
-				double t = static_cast<double>(_movementFrames - 1) / effectiveDuration;
-				double tNext = static_cast<double>(_movementFrames) / effectiveDuration;
-				double h = _arcHeight;
-				double deflPrev = 4.0 * h * t * (1.0 - t);
-				double deflNext = 4.0 * h * tNext * (1.0 - tNext);
-				double delta = deflNext - deflPrev;
+				double t = static_cast<double>(_movementFrames) / effectiveDuration;
+				double arcOffset = CalcArcOffsetAt(t);
+				double baseX = _initialLocation.X + (frameTarget.X - _initialLocation.X) * t;
+				double baseY = _initialLocation.Y + (frameTarget.Y - _initialLocation.Y) * t;
+				double baseZ = _initialLocation.Z + (frameTarget.Z - _initialLocation.Z) * t;
 
 				if (_arcRotation == 0.0)
 				{
-					resultDisp.Z += static_cast<int>(delta);
+					resultDisp.X = static_cast<int>(baseX - currentPos.X);
+					resultDisp.Y = static_cast<int>(baseY - currentPos.Y);
+					resultDisp.Z = static_cast<int>(baseZ + arcOffset - currentPos.Z);
 				}
 				else
 				{
-					// D = start→target 方向
 					double dx = frameTarget.X - _initialLocation.X;
 					double dy = frameTarget.Y - _initialLocation.Y;
 					double dz = frameTarget.Z - _initialLocation.Z;
@@ -972,39 +1009,42 @@ VectorResult VectorEffect::GetVectorResult()
 					if (dLen > 1e-6)
 					{
 						double dnx = dx / dLen, dny = dy / dLen, dnz = dz / dLen;
-						// 默认弧面法向 = 世界朝上垂直于 D 的分量
 						double upDotD = dnz;
 						double px = -dnx * upDotD, py = -dny * upDotD, pz = 1.0 - dnz * upDotD;
 						double pLen = std::sqrt(px * px + py * py + pz * pz);
 						if (pLen < 1e-6)
 						{
-							// D 接近垂直，用水平朝北
 							px = 1.0 - dnx * dnx; py = -dny * dnx; pz = -dnz * dnx;
 							pLen = std::sqrt(px * px + py * py + pz * pz);
 						}
 						double pnx = px / pLen, pny = py / pLen, pnz = pz / pLen;
-						// 绕 D 旋转 P
 						double rad = Math::deg2rad(_arcRotation);
 						double c = std::cos(rad), s = std::sin(rad);
 						double rx = pnx * c + (dny * pnz - dnz * pny) * s;
 						double ry = pny * c + (dnz * pnx - dnx * pnz) * s;
 						double rz = pnz * c + (dnx * pny - dny * pnx) * s;
-						resultDisp.X += static_cast<int>(rx * delta);
-						resultDisp.Y += static_cast<int>(ry * delta);
-						resultDisp.Z += static_cast<int>(rz * delta);
+						resultDisp.X = static_cast<int>(baseX + rx * arcOffset - currentPos.X);
+						resultDisp.Y = static_cast<int>(baseY + ry * arcOffset - currentPos.Y);
+						resultDisp.Z = static_cast<int>(baseZ + rz * arcOffset - currentPos.Z);
 					}
 					else
 					{
-						resultDisp.Z += static_cast<int>(delta);
+						resultDisp.X = static_cast<int>(baseX - currentPos.X);
+						resultDisp.Y = static_cast<int>(baseY - currentPos.Y);
+						resultDisp.Z = static_cast<int>(baseZ + arcOffset - currentPos.Z);
 					}
 				}
 			}
 		}
+		result.MoveDisp = resultDisp;
+		AdvanceFrame();
+		return result;
 	}
+
 	// ========================================================================
-	// 成熟机制，别乱动 — 模式 3: Speed（直线追踪 + 加速度）
+	// 模式5: Speed（直线追踪 + 加速度）
 	// ========================================================================
-	else if (dirLen > 1e-6)
+	if (Data->LinearSpeed >= 0)
 	{
 		double speed = _currentSpeed;
 
@@ -1020,13 +1060,75 @@ VectorResult VectorEffect::GetVectorResult()
 		if (Data->MaxSpeed >= 0 && speed > Data->MaxSpeed)
 			speed = static_cast<double>(Data->MaxSpeed);
 
-		resultDisp.X = static_cast<int>(dirVec.X / dirLen * speed);
-		resultDisp.Y = static_cast<int>(dirVec.Y / dirLen * speed);
-		resultDisp.Z = static_cast<int>(dirVec.Z / dirLen * speed);
+		if (dirLen > 1e-6)
+		{
+			// 抵达目标坐标点即结束AE，钳位到目标点避免飞越后抽搐
+			if (Data->SpeedEndOnReach && dirLen <= speed)
+			{
+				result.MoveDisp = dirVec;
+				Deactivate();
+				AdvanceFrame();
+				return result;
+			}
+			resultDisp.X = static_cast<int>(dirVec.X / dirLen * speed);
+			resultDisp.Y = static_cast<int>(dirVec.Y / dirLen * speed);
+			resultDisp.Z = static_cast<int>(dirVec.Z / dirLen * speed);
+
+			// 弧高增量叠加（与直线推进解耦，speed 仅代表直线速度）
+			if (_arcHeight != 0)
+			{
+				if (_speedArcTotalDist < 0.0)
+					_speedArcTotalDist = dirLen;
+				double t = (_speedArcTotalDist > 1e-6) ? 1.0 - dirLen / _speedArcTotalDist : 0.0;
+				if (t < 0.0) t = 0.0; else if (t > 1.0) t = 1.0;
+				double arcThis = CalcArcOffsetAt(t);
+				double arcDelta = arcThis - _prevArcOffset;
+				_prevArcOffset = arcThis;
+
+				if (_arcRotation == 0.0)
+				{
+					resultDisp.Z += static_cast<int>(arcDelta);
+				}
+				else
+				{
+					double dx = frameTarget.X - _initialLocation.X;
+					double dy = frameTarget.Y - _initialLocation.Y;
+					double dz = frameTarget.Z - _initialLocation.Z;
+					double dLen = std::sqrt(dx * dx + dy * dy + dz * dz);
+					if (dLen > 1e-6)
+					{
+						double dnx = dx / dLen, dny = dy / dLen, dnz = dz / dLen;
+						double upDotD = dnz;
+						double px = -dnx * upDotD, py = -dny * upDotD, pz = 1.0 - dnz * upDotD;
+						double pLen = std::sqrt(px * px + py * py + pz * pz);
+						if (pLen < 1e-6)
+						{
+							px = 1.0 - dnx * dnx; py = -dny * dnx; pz = -dnz * dnx;
+							pLen = std::sqrt(px * px + py * py + pz * pz);
+						}
+						double pnx = px / pLen, pny = py / pLen, pnz = pz / pLen;
+						double rad = Math::deg2rad(_arcRotation);
+						double c = std::cos(rad), s = std::sin(rad);
+						double rx = pnx * c + (dny * pnz - dnz * pny) * s;
+						double ry = pny * c + (dnz * pnx - dnx * pnz) * s;
+						double rz = pnz * c + (dnx * pny - dny * pnx) * s;
+						resultDisp.X += static_cast<int>(rx * arcDelta);
+						resultDisp.Y += static_cast<int>(ry * arcDelta);
+						resultDisp.Z += static_cast<int>(rz * arcDelta);
+					}
+					else
+					{
+						resultDisp.Z += static_cast<int>(arcDelta);
+					}
+				}
+			}
+		}
+		result.MoveDisp = resultDisp;
+		AdvanceFrame();
+		return result;
 	}
 
-	result.MoveDisp = resultDisp;
-
+	// 没命中任何模式，返回空
 	AdvanceFrame();
 	return result;
 }

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -32,6 +32,7 @@ void VectorEffect::OnStart()
 	_prevCircleCenter = pObject->GetCoords();
 
 	_initialLocation = pObject->GetCoords();
+	_vectorAcquireZ = _initialLocation.Z;  // Circle 圆心高度基准：获取 Vector 时的 Z
 	_totalDuration = AE->GetDuration() / _effectiveTimeStep;
 
 	_randomTargetOffset.X = Random::RandomRanged(Data->TargetOffsetFMin, Data->TargetOffsetFMax);
@@ -762,11 +763,17 @@ VectorResult VectorEffect::GetVectorResult()
 				disp.Y = newOffset.Y - _originOffset.Y;
 				disp.Z = newOffset.Z - _originOffset.Z;
 			}
-		skipOriginUpdate:
-			_originOffset.X += disp.X; _originOffset.Y += disp.Y; _originOffset.Z += disp.Z;
-			circleCenter = baseCenter + _originOffset;
-			_originElapsed++;
-		}
+	skipOriginUpdate:
+		_originOffset.X += disp.X; _originOffset.Y += disp.Y; _originOffset.Z += disp.Z;
+		circleCenter = baseCenter + _originOffset;
+		_originElapsed++;
+	}
+
+	// Circle 圆心 Z 高度规则（OriginFLH 做相对偏移，CircleOrigin 做绝对覆写）
+	if (!Data->CircleOrigin.IsEmpty())
+		circleCenter.Z = Data->OriginFLH.Z + Data->CircleOrigin.Z;
+	else if (!Data->OriginFLH.IsEmpty())
+		circleCenter.Z = _vectorAcquireZ + Data->OriginFLH.Z;
 
 	// 圆心位移叠加：Circle 模式追踪圆心→调整 currentPos
 	CoordStruct centerDelta{ 0, 0, 0 };  // 初始化避免 C4701 警告
@@ -854,7 +861,8 @@ VectorResult VectorEffect::GetVectorResult()
 			double ry = ndx * sinA + ndy * cosA;
 			result.MoveDisp.X = circleCenter.X + static_cast<int>(rx) - currentPos.X;
 			result.MoveDisp.Y = circleCenter.Y + static_cast<int>(ry) - currentPos.Y;
-			result.MoveDisp.Z = circleCenter.Z - currentPos.Z;
+			result.MoveDisp.Z = Data->CircleOrigin.IsEmpty() && Data->OriginFLH.IsEmpty()
+				? 0 : circleCenter.Z - currentPos.Z;  // 有显式高度指定时拉 Z，否则维持抛射体自身高度
 		}
 		result.Force = true;
 

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -12,9 +12,6 @@
 #include <Ext/EffectType/AttachEffectScript.h>
 #include <Ext/BulletType/BulletStatus.h>
 
-// 跨 AE 链路目标坐标缓存
-std::map<TechnoClass*, CoordStruct> VectorEffect::_lastTargetCache;
-
 
 // Vector: Freeze / Circle / MoveTo / Speed / ReachTarget
 // 基于 V1 VectorEffect.cpp 精简
@@ -113,10 +110,6 @@ void VectorEffect::OnStart()
 		_pLauncher = (AE && AE->pSource) ? AE->pSource : pTechno; // 单位侧用攻击者作为Launcher
 	}
 
-	// 缓存：只要单位有攻击目标就记录，不限Origin类型，供AE链路后续使用
-	if (pTechno && pTechno->Target && abstract_cast<ObjectClass*>(pTechno->Target) && !IsDeadOrInvisible(abstract_cast<ObjectClass*>(pTechno->Target)))
-		_lastTargetCache[pTechno] = pTechno->Target->GetCoords();
-
 	// --- Origin 初始化 ---
 	switch (Data->Origin)
 	{
@@ -127,8 +120,6 @@ void VectorEffect::OnStart()
 			if (pTechno)
 			{
 				_initialOriginPos = pTechno->GetCoords();
-				if (pTechno->Target && abstract_cast<ObjectClass*>(pTechno->Target) && !IsDeadOrInvisible(abstract_cast<ObjectClass*>(pTechno->Target)))
-					_lastTargetCache[pTechno] = pTechno->Target->GetCoords();
 			}
 			else if (pBullet)
 				_initialOriginPos = pBullet->TargetCoords;
@@ -383,21 +374,6 @@ VectorResult VectorEffect::GetVectorResult()
 		return result;
 	}
 	_movementFrames++;
-
-	// 每帧更新缓存：即使OnStart时Target为空，后续帧获取后也能传递
-	if (pTechno)
-	{
-		CoordStruct cached{};
-		bool got = false;
-		if (pTechno->Target) { cached = pTechno->Target->GetCoords(); got = true; }
-		else {
-			FootClass* pf = abstract_cast<FootClass*>(pTechno);
-			if (pf && pf->Destination) { cached = pf->Destination->GetCoords(); got = true; }
-			else if (pTechno->Focus) { cached = pTechno->Focus->GetCoords(); got = true; }
-		}
-		if (got)
-			_lastTargetCache[pTechno] = cached;
-	}
 
 	_normalRotF += _lissajousStep;
 	// 3D 法向量增量旋转（绕世界 F=Y / L=X / H=Z 轴，正速度=顺时针）
@@ -872,9 +848,12 @@ VectorResult VectorEffect::GetVectorResult()
 					switch (Data->OriginOrigin)
 					{
 					case VectorData::VectorOrigin::Launcher:
-						if (_pLauncher && !IsDeadOrInvisible(_pLauncher))
-							_originFacing = abstract_cast<TechnoClass*>(_pLauncher)->TurretFacing().Current().GetRadian();
-						else if (pTechno) _originFacing = pTechno->TurretFacing().Current().GetRadian();
+						{
+							TechnoClass* pLT = abstract_cast<TechnoClass*>(_pLauncher);
+							if (pLT && !IsDeadOrInvisible(pLT))
+								_originFacing = pLT->TurretFacing().Current().GetRadian();
+							else if (pTechno) _originFacing = pTechno->TurretFacing().Current().GetRadian();
+						}
 						break;
 					case VectorData::VectorOrigin::Target:
 						if (pBullet) { auto tp = pBullet->TargetCoords; auto bp = pBullet->GetCoords(); _originFacing = std::atan2(bp.Y-tp.Y, bp.X-tp.X); }

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -54,6 +54,21 @@ void VectorEffect::OnStart()
 	if (_arcPeakPercent <= 0.0) _arcPeakPercent = 0.5;
 	if (_arcPeakPercent >= 1.0) _arcPeakPercent = 0.5;
 
+	// Origin 弧参数（镜像小圆）
+	_originArcRotation = Data->OriginArcRotation;
+	if (Data->OriginArcRandomRotationMax > Data->OriginArcRandomRotationMin)
+		_originArcRotation = Data->OriginArcRandomRotationMin + (Data->OriginArcRandomRotationMax - Data->OriginArcRandomRotationMin) * Random::RandomDouble();
+
+	_originArcHeight = Data->OriginArcHeight;
+	if (Data->OriginArcRandomHeightMax > Data->OriginArcRandomHeightMin)
+		_originArcHeight = Random::RandomRanged(Data->OriginArcRandomHeightMin, Data->OriginArcRandomHeightMax);
+
+	_originArcPeakPercent = Data->OriginArcPeakPercent / 100.0;
+	if (Data->OriginArcPeakRandomPercent.X < Data->OriginArcPeakRandomPercent.Y)
+		_originArcPeakPercent = Random::RandomRanged(Data->OriginArcPeakRandomPercent.X, Data->OriginArcPeakRandomPercent.Y) / 100.0;
+	if (_originArcPeakPercent <= 0.0) _originArcPeakPercent = 0.5;
+	if (_originArcPeakPercent >= 1.0) _originArcPeakPercent = 0.5;
+
 	// 影子坐标（Speed 模式弧高进度基准，不受弧高 Z 偏移污染）
 	_shadowPosX = _initialLocation.X;
 	_shadowPosY = _initialLocation.Y;
@@ -662,7 +677,7 @@ VectorResult VectorEffect::GetVectorResult()
 	}
 
 		// 圆心移动：Vector.Origin.* 系统
-		if (!Data->OriginMoveTo.IsEmpty() || !Data->OriginTargetFLH.IsEmpty()
+		if (!Data->OriginMoveTo.IsEmpty() || Data->OriginReachTarget || Data->OriginLinearSpeed >= 0 || !Data->OriginTargetFLH.IsEmpty()
 			|| Data->OriginCircleRadius >= 0 || Data->OriginCircleSpeed != 0 || Data->OriginCircleAnglePerStep != 0)
 		{
 			// 基座：默认 originPos，OriginOrigin 可替换为独立参考系
@@ -707,6 +722,12 @@ VectorResult VectorEffect::GetVectorResult()
 			// Origin.CircleOffset 世界偏移
 			if (!Data->OriginCircleOffset.IsEmpty())
 				baseCenter = baseCenter + Data->OriginCircleOffset;
+
+			// OriginNoUpdate：首帧快照基座，后续帧冻结
+			if (_elapsedFrames == 0)
+				_initialBaseCenter = baseCenter;
+			else if (Data->OriginOriginNoUpdate)
+				baseCenter = _initialBaseCenter;
 
 			if (_elapsedFrames == 0)
 			{
@@ -836,11 +857,14 @@ VectorResult VectorEffect::GetVectorResult()
 				growOffset = Data->OriginGrowRate * _originElapsed;
 				disp = GetFLHAbsoluteOffset(Data->OriginMoveTo + growOffset, Radians2Dir(oFacing + Math::deg2rad(_originAngle))); // 官方API，不得修改
 			}
-			else if (!Data->OriginTargetFLH.IsEmpty())
+			else if (Data->OriginReachTarget || Data->OriginLinearSpeed >= 0 || !Data->OriginTargetFLH.IsEmpty())
 			{
 				// Speed / ReachTarget
 				if (_originElapsed == 0)
+				{
 					_originSpeed = Data->OriginLinearSpeed >= 0 ? Data->OriginLinearSpeed : (pTechno ? pTechno->GetTechnoType()->Speed : 40.0);
+					_originArcStartCenter = originCenter;
+				}
 
 				CoordStruct targetWorld = GetFLHAbsoluteCoords(baseCenter, Data->OriginTargetFLH + _originTargetOffset, oFacingDir); // 官方API，不得修改
 				if (Data->OriginReachTarget)
@@ -862,11 +886,45 @@ VectorResult VectorEffect::GetVectorResult()
 					disp.X = (targetWorld.X - originCenter.X) / rem;
 					disp.Y = (targetWorld.Y - originCenter.Y) / rem;
 					disp.Z = (targetWorld.Z - originCenter.Z) / rem;
-					if (Data->OriginArcHeight)
+					if (_originArcHeight != 0)
 					{
-						int total = _totalDuration / _effectiveTimeStep;
-						double t = total>0 ? (double)_originElapsed/total : 0, t0 = total>0 ? (double)(_originElapsed-1)/total : 0;
-						disp.Z += (int)(4.0*Data->OriginArcHeight*(t*(1-t) - t0*(1-t0)));
+						double t = static_cast<double>(_movementFrames) / effectiveSteps;
+						double arcOffset = CalcArcOffsetAt(_originArcHeight, _originArcPeakPercent, t);
+						double baseX = _originArcStartCenter.X + (targetWorld.X - _originArcStartCenter.X) * t;
+						double baseY = _originArcStartCenter.Y + (targetWorld.Y - _originArcStartCenter.Y) * t;
+						double baseZ = _originArcStartCenter.Z + (targetWorld.Z - _originArcStartCenter.Z) * t;
+						if (_originArcRotation == 0.0)
+						{
+							disp.Z = static_cast<int>(baseZ + arcOffset) - originCenter.Z;
+						}
+						else
+						{
+							double dx = targetWorld.X - _originArcStartCenter.X;
+							double dy = targetWorld.Y - _originArcStartCenter.Y;
+							double dz = targetWorld.Z - _originArcStartCenter.Z;
+							double dLen = std::sqrt(dx*dx + dy*dy + dz*dz);
+							if (dLen > 1e-6)
+							{
+								double dnx = dx/dLen, dny = dy/dLen, dnz = dz/dLen;
+								double upDotD = dnz;
+								double px = -dnx*upDotD, py = -dny*upDotD, pz = 1.0 - dnz*upDotD;
+								double pLen = std::sqrt(px*px + py*py + pz*pz);
+								if (pLen < 1e-6) { px = 1.0-dnx*dnx; py = -dny*dnx; pz = -dnz*dnx; pLen = std::sqrt(px*px+py*py+pz*pz); }
+								double pnx = px/pLen, pny = py/pLen, pnz = pz/pLen;
+								double rad = Math::deg2rad(_originArcRotation);
+								double c = std::cos(rad), s = std::sin(rad);
+								double rx = pnx*c + (dny*pnz - dnz*pny)*s;
+								double ry = pny*c + (dnz*pnx - dnx*pnz)*s;
+								double rz = pnz*c + (dnx*pny - dny*pnx)*s;
+								disp.X = static_cast<int>(baseX + rx*arcOffset) - originCenter.X;
+								disp.Y = static_cast<int>(baseY + ry*arcOffset) - originCenter.Y;
+								disp.Z = static_cast<int>(baseZ + rz*arcOffset) - originCenter.Z;
+							}
+							else
+							{
+								disp.Z = static_cast<int>(baseZ + arcOffset) - originCenter.Z;
+							}
+						}
 					}
 				}
 				else
@@ -884,17 +942,48 @@ VectorResult VectorEffect::GetVectorResult()
 					}
 					else { double s = _originSpeed / dist; disp.X = (int)(dx*s); disp.Y = (int)(dy*s); disp.Z = (int)(dz*s); }
 
-					// 弧高增量叠加（简化抛物线，与 OriginReachTarget 一致）
-					if (Data->OriginArcHeight != 0 && dist >= 1.0)
+					// 弧高增量叠加（与 OriginReachTarget 一致，支持 ArcPeakPercent / ArcRotation）
+					if (_originArcHeight != 0 && dist >= 1.0)
 					{
 						if (_originArcTotalDist < 0.0)
 							_originArcTotalDist = dist;
 						double t = (_originArcTotalDist > 1e-6) ? 1.0 - dist / _originArcTotalDist : 0.0;
 						if (t < 0.0) t = 0.0; else if (t > 1.0) t = 1.0;
-						double arcThis = 4.0 * Data->OriginArcHeight * t * (1.0 - t);
+						double arcThis = CalcArcOffsetAt(_originArcHeight, _originArcPeakPercent, t);
 						double arcDelta = arcThis - _originPrevArcOffset;
 						_originPrevArcOffset = arcThis;
-						disp.Z += static_cast<int>(arcDelta);
+						if (_originArcRotation == 0.0)
+						{
+							disp.Z += static_cast<int>(arcDelta);
+						}
+						else
+						{
+							double dx0 = targetWorld.X - _originArcStartCenter.X;
+							double dy0 = targetWorld.Y - _originArcStartCenter.Y;
+							double dz0 = targetWorld.Z - _originArcStartCenter.Z;
+							double dLen = std::sqrt(dx0*dx0 + dy0*dy0 + dz0*dz0);
+							if (dLen > 1e-6)
+							{
+								double dnx = dx0/dLen, dny = dy0/dLen, dnz = dz0/dLen;
+								double upDotD = dnz;
+								double px = -dnx*upDotD, py = -dny*upDotD, pz = 1.0 - dnz*upDotD;
+								double pLen = std::sqrt(px*px + py*py + pz*pz);
+								if (pLen < 1e-6) { px = 1.0-dnx*dnx; py = -dny*dnx; pz = -dnz*dnx; pLen = std::sqrt(px*px+py*py+pz*pz); }
+								double pnx = px/pLen, pny = py/pLen, pnz = pz/pLen;
+								double rad = Math::deg2rad(_originArcRotation);
+								double c = std::cos(rad), s = std::sin(rad);
+								double rx = pnx*c + (dny*pnz - dnz*pny)*s;
+								double ry = pny*c + (dnz*pnx - dnx*pnz)*s;
+								double rz = pnz*c + (dnx*pny - dny*pnx)*s;
+								disp.X += static_cast<int>(rx * arcDelta);
+								disp.Y += static_cast<int>(ry * arcDelta);
+								disp.Z += static_cast<int>(rz * arcDelta);
+							}
+							else
+							{
+								disp.Z += static_cast<int>(arcDelta);
+							}
+						}
 					}
 				}
 			}

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -55,8 +55,10 @@ void VectorEffect::OnStart()
 		else
 		{
 			// XY 圆环：角度默认全向，TargetOffsetAngles 限制时按区间加权均匀
-			// FLH 系角 = -90°-deg：消费端 GetFLHAbsoluteOffset 世界角 = -(mainFacingDir + flhAngle)，
-			// Origin=Target 时 mainFacingDir=近交点方向，世界落点角 = 近交点角 + deg，以近交点对称
+			// 消费端 GetFLHAbsoluteOffset 世界角 = -(mainFacingDir + flhAngle)，要求 = 近交点角 + deg：
+			// flhAngle = -mainFacingDirSim - β - deg
+			//   β = atan2 近交点世界角（目标点指向抛射体）
+			//   mainFacingDirSim = 复刻消费端取值：NoUpdate=yes 用 DirStruct 原值(α)，no 用 Radians2Dir(α)（差 90°）
 			double flhAngle;
 			bool hasAngleRange = (Data->TargetOffsetAngleMin < Data->TargetOffsetAngleMax)
 				|| (Data->TargetOffsetAngleMin2 < Data->TargetOffsetAngleMax2);
@@ -72,7 +74,33 @@ void VectorEffect::OnStart()
 					deg = Data->TargetOffsetAngleMin + u;
 				else
 					deg = Data->TargetOffsetAngleMin2 + (u - (len1 > 0 ? len1 : 0.0));
-				flhAngle = Math::deg2rad(-90.0 - deg);
+				// 近交点基准：targetPos 取 pBullet->TargetCoords（与 OnStart 326 行 _facingDir 一致）
+				bool hasBase = false;
+				CoordStruct bulletPos = pObject->GetCoords();
+				CoordStruct targetPos{};
+				if (pBullet)
+				{
+					targetPos = pBullet->TargetCoords;
+					hasBase = true;
+				}
+				else if (pTechno && pTechno->Target)
+				{
+					targetPos = pTechno->Target->GetCoords();
+					hasBase = true;
+				}
+				if (hasBase)
+				{
+					double beta = std::atan2(bulletPos.Y - targetPos.Y, bulletPos.X - targetPos.X); // 近交点世界角
+					double alpha = Point2Dir(targetPos, bulletPos).GetRadian(); // 近交点 DirStruct 角
+					double mainFacingDirSim = Data->OriginNoUpdate
+						? alpha
+						: Radians2Dir(alpha).GetRadian(); // 复刻消费端 mainFacingDir 取值路径
+					flhAngle = -mainFacingDirSim - beta - Math::deg2rad(deg);
+				}
+				else
+				{
+					flhAngle = Random::RandomDouble() * 2.0 * M_PI; // 拿不到连线方向：回退全向
+				}
 			}
 			else
 			{

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -435,7 +435,9 @@ VectorResult VectorEffect::GetVectorResult()
 	// AllowOriginTilt：从 Origin 单位获取倾斜，注入 _facingRad/_tiltRad（同 NormalVector 机制）
 	// 仅 Circle 模式生效，避免非 Circle 模式覆盖 OnStart 的方向
 	double originTerrainTilt = 0.0;
-	bool hasCircleForTilt = Data->CircleRadius > 0 || Data->CircleAnglePerStep > 0.0;
+	bool hasCircleForTilt = Data->CircleRadius > 0 || Data->CircleAnglePerStep > 0.0
+		|| (Data->CircleRandomRadiusMax > Data->CircleRandomRadiusMin)
+		|| (Data->CircleRandomAngleMax > Data->CircleRandomAngleMin);
 	if ((Data->AllowOriginTilt || Data->OriginAllowOriginTilt) && hasCircleForTilt && !Data->OriginIsOnWorld)
 	{
 		TechnoClass* pOriginTechno = nullptr;
@@ -977,7 +979,7 @@ VectorResult VectorEffect::GetVectorResult()
 				CoordStruct targetWorld = GetFLHAbsoluteCoords(baseCenter, Data->OriginTargetFLH + _originTargetOffset, oFacingDir); // 官方API，不得修改
 				if (Data->OriginReachTarget)
 				{
-					int effectiveSteps = (_totalDuration - Data->DisabledFrames) / _effectiveTimeStep;
+					int effectiveSteps = (AE->AEData.GetDuration() - Data->DisabledFrames) / _effectiveTimeStep;
 					if (effectiveSteps < 1) effectiveSteps = 1;
 					int rem = effectiveSteps - _movementFrames;
 					if (rem <= 0)

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -1424,14 +1424,16 @@ VectorResult VectorEffect::GetVectorResult()
 			resultDisp.Y = static_cast<int>(dirVec.Y / dirLen * adjustedSpeed);
 			resultDisp.Z = static_cast<int>(dirVec.Z / dirLen * adjustedSpeed);
 
-			// 抛物线弧高（基于初始位置，支持 ArcPeakPercent / ArcRotation）
+			// 抛物线弧高（基于弧线起点，支持 ArcPeakPercent / ArcRotation）
 			if (_arcHeight != 0)
 			{
+				if (_arcStartLocation.IsEmpty())
+					_arcStartLocation = currentPos; // 首次弧线执行时抓取当前位置作为起点
 				double t = static_cast<double>(_movementFrames) / effectiveDuration;
 				double arcOffset = CalcArcOffsetAt(t);
-				double baseX = _initialLocation.X + (frameTarget.X - _initialLocation.X) * t;
-				double baseY = _initialLocation.Y + (frameTarget.Y - _initialLocation.Y) * t;
-				double baseZ = _initialLocation.Z + (frameTarget.Z - _initialLocation.Z) * t;
+				double baseX = _arcStartLocation.X + (frameTarget.X - _arcStartLocation.X) * t;
+				double baseY = _arcStartLocation.Y + (frameTarget.Y - _arcStartLocation.Y) * t;
+				double baseZ = _arcStartLocation.Z + (frameTarget.Z - _arcStartLocation.Z) * t;
 
 				if (_arcRotation == 0.0)
 				{
@@ -1441,9 +1443,9 @@ VectorResult VectorEffect::GetVectorResult()
 				}
 				else
 				{
-					double dx = frameTarget.X - _initialLocation.X;
-					double dy = frameTarget.Y - _initialLocation.Y;
-					double dz = frameTarget.Z - _initialLocation.Z;
+					double dx = frameTarget.X - _arcStartLocation.X;
+					double dy = frameTarget.Y - _arcStartLocation.Y;
+					double dz = frameTarget.Z - _arcStartLocation.Z;
 					double dLen = std::sqrt(dx * dx + dy * dy + dz * dz);
 					if (dLen > 1e-6)
 					{

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -132,9 +132,23 @@ void VectorEffect::CacheTargetNow()
 
 	if (pTechno->SpawnOwner && !IsDeadOrInvisible(pTechno->SpawnOwner))
 	{
-		// Spawn 导弹：SpawnManager（单位+坐标）→ Kamikaze Cell（只有格子）→ Target（单位+坐标）
+		// Spawn 导弹：优先从发射者（SpawnOwner）自身攻击目标读——
+		// 引擎集结阶段 SpawnManager 的 Target/Destination 可能是集结点，发射者自己瞄准的目标才是真实目标
+		if (pTechno->SpawnOwner->Target)
+		{
+			TechnoClass* pTgt = abstract_cast<TechnoClass*>(pTechno->SpawnOwner->Target);
+			CoordStruct c = pTechno->SpawnOwner->Target->GetCoords();
+			if (!IsSameCell(c, pTechno->GetCoords())
+				&& (!pTgt || !IsDeadOrInvisible(pTgt))) // 非 Techno 目标（格子）不做死亡判断
+			{
+				candTarget = pTechno->SpawnOwner->Target;
+				candCell = c;
+				got = true;
+			}
+		}
+		// 原链兜底：SpawnManager（单位+坐标）→ Kamikaze Cell（只有格子）→ Target（单位+坐标）
 		SpawnManagerClass* pSM = pTechno->SpawnOwner->SpawnManager;
-		if (pSM && pSM->Target)
+		if (!got && pSM && pSM->Target)
 		{
 			TechnoClass* pTgt = abstract_cast<TechnoClass*>(pSM->Target);
 			CoordStruct c = pSM->Target->GetCoords();
@@ -948,26 +962,38 @@ VectorResult VectorEffect::GetVectorResult()
 			originPos = _initialOriginPos.IsEmpty() ? currentPos : _initialOriginPos; // 锁定初始目标
 		else
 		{
-			// 允许更新：每帧从引擎读目标跟随移动（NoUpdate=no 语义）；
-			// 更新结果变成导弹自身格子（目标死亡，引擎重置）时抛弃该帧，回退到已锁定坐标
+			// 允许更新（NoUpdate=no）：缓存优先（只跟随锁定单位，防引擎集结目标点污染），
+			// 缓存空才回退引擎链；更新结果变成脚下格子（目标死亡）时抛弃，回退锁定坐标
 			CoordStruct updated{};
 			bool gotUpdate = false;
-			if (pBullet && pBullet->Target)
+			if (pTechno)
+			{
+				if (TechnoStatus* status = GetStatus<TechnoExt, TechnoStatus>(pTechno))
+				{
+					if (status->HasVectorTargetCache()
+						&& !IsSameCell(status->GetVectorCachedCell(), pTechno->GetCoords()))
+					{
+						updated = status->GetVectorCachedCell();
+						gotUpdate = true;
+					}
+				}
+			}
+			if (!gotUpdate && pBullet && pBullet->Target)
 			{
 				updated = pBullet->Target->GetCoords(); // 抛射体目标 Cell 是真实落点，不判脚下
 				gotUpdate = true;
 			}
-			else if (pBullet)
+			else if (!gotUpdate && pBullet)
 			{
 				updated = pBullet->TargetCoords;
 				gotUpdate = true;
 			}
-			else if (pTechno && pTechno->Target && !IsSelfCellTarget(pTechno, pTechno->Target))
+			else if (!gotUpdate && pTechno && pTechno->Target && !IsSelfCellTarget(pTechno, pTechno->Target))
 			{
 				updated = pTechno->Target->GetCoords();
 				gotUpdate = true;
 			}
-			else if (pTechno)
+			else if (!gotUpdate && pTechno)
 			{
 				CoordStruct kamikazePos{};
 				if ((TryGetKamikazeTarget(pTechno, kamikazePos) || TryGetSpawnManagerTarget(pTechno, kamikazePos))

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -336,6 +336,62 @@ VectorResult VectorEffect::GetVectorResult()
 	// ========================================================================
 	// 动态 F 轴：非 NoUpdate 时每帧根据当前坐标重新计算 FLH 朝向
 	// ========================================================================
+
+	// AllowOriginTilt：从 Origin 单位获取倾斜，注入 _facingRad/_tiltRad（同 NormalVector 机制）
+	double originTerrainTilt = 0.0;
+	if (Data->AllowOriginTilt && !Data->OriginIsOnWorld)
+	{
+		TechnoClass* pOriginTechno = nullptr;
+		switch (Data->Origin)
+		{
+		case VectorData::VectorOrigin::Target:
+			if (pBullet && pBullet->Target)
+				pOriginTechno = abstract_cast<TechnoClass*>(pBullet->Target);
+			else if (pTechno && pTechno->Target)
+				pOriginTechno = abstract_cast<TechnoClass*>(pTechno->Target);
+			break;
+		case VectorData::VectorOrigin::Source:
+			pOriginTechno = abstract_cast<TechnoClass*>(_pSource);
+			break;
+		case VectorData::VectorOrigin::Launcher:
+			pOriginTechno = abstract_cast<TechnoClass*>(_pLauncher);
+			break;
+		case VectorData::VectorOrigin::Self:
+			pOriginTechno = pTechno;
+			break;
+		}
+		if (pOriginTechno && !IsDeadOrInvisible(pOriginTechno))
+		{
+			// 优先用引擎动态倾斜（Rocker等），为 0 时从地形采样
+			originTerrainTilt = pOriginTechno->AngleRotatedForwards;
+			if (std::abs(originTerrainTilt) < 1e-6)
+			{
+				CoordStruct originCoord = pOriginTechno->GetCoords();
+				double unitFacing = pOriginTechno->PrimaryFacing.Current().GetRadian();
+				double cosF = std::cos(unitFacing), sinF = std::sin(unitFacing);
+				Point2D frontPt = { originCoord.X + static_cast<int>(128.0 * cosF), originCoord.Y + static_cast<int>(128.0 * sinF) };
+				Point2D backPt  = { originCoord.X - static_cast<int>(128.0 * cosF), originCoord.Y - static_cast<int>(128.0 * sinF) };
+				int hFront = MapClass::Instance->GetCellFloorHeight({frontPt.X, frontPt.Y, 0});
+				int hBack  = MapClass::Instance->GetCellFloorHeight({backPt.X, backPt.Y, 0});
+				double dz = static_cast<double>(hFront - hBack);
+				double dxy = 256.0;
+				originTerrainTilt = (dxy > 1e-6) ? std::atan2(dz, dxy) : 0.0;
+			}
+
+			// 注入 _facingRad/_tiltRad（同 NormalVector 机制）
+			// 单位倾斜 = 默认法向量 (0,0,1) 绕单位 L 轴旋转 originTerrainTilt
+			// L 轴 = (-sinF, cosF, 0)，绕 L 轴旋转后法向量 = (-sinT*sinF, sinT*cosF, cosT)
+			double unitFacing2 = pOriginTechno->PrimaryFacing.Current().GetRadian();
+			double sinT = std::sin(originTerrainTilt), cosT = std::cos(originTerrainTilt);
+			double nx = -sinT * std::sin(unitFacing2);
+			double ny = sinT * std::cos(unitFacing2);
+			double nz = cosT;
+			double nLenXY = std::sqrt(nx * nx + ny * ny);
+			_facingRad = nLenXY > 1e-6 ? std::atan2(ny, nx) : 0.0;
+			_tiltRad = nLenXY > 1e-6 ? std::atan2(nz, nLenXY) : (nz > 0 ? M_PI / 2.0 : -M_PI / 2.0);
+		}
+	}
+
 	double effectiveFacing = _facingRad + Math::deg2rad(_normalRotH);
 	double effectiveTilt = _tiltRad + Math::deg2rad(_normalRotL);
 	DirStruct mainFacingDir = Radians2Dir(effectiveFacing); // 官方API，不得修改：引擎弧度→DirStruct转换
@@ -352,7 +408,7 @@ VectorResult VectorEffect::GetVectorResult()
 		|| Data->NormalRandomF.Y > Data->NormalRandomF.X
 		|| Data->NormalRandomL.Y > Data->NormalRandomL.X
 		|| Data->NormalRandomH.Y > Data->NormalRandomH.X;
-	if (!Data->OriginNoUpdate && !hasNormal && !Data->OriginIsOnWorld)
+	if (!Data->OriginNoUpdate && !hasNormal && !Data->AllowOriginTilt && !Data->OriginIsOnWorld)
 	{
 		switch (Data->Origin)
 		{
@@ -453,10 +509,12 @@ VectorResult VectorEffect::GetVectorResult()
 		break;
 	}
 
-	// OriginFLH 偏移：对非 Self 模式生效，直接使用引擎 DirStruct
+	// OriginFLH 偏移：对非 Self 模式生效
+	// AllowOriginTilt 时跳过二维 GetFLHAbsoluteCoords，后续用三维旋转处理
+	if (!Data->AllowOriginTilt)
 	{
 		if (!Data->OriginFLH.IsEmpty() && Data->Origin != VectorData::VectorOrigin::Self)
-			originPos = GetFLHAbsoluteCoords(originPos, Data->OriginFLH, mainFacingDir); // 官方API，不得修改
+			originPos = GetFLHAbsoluteCoords(originPos, Data->OriginFLH, mainFacingDir);
 	}
 
 	// ========================================================================
@@ -522,15 +580,86 @@ VectorResult VectorEffect::GetVectorResult()
 		else if (speed > 0.0)
 			angleStep = Math::rad2deg(speed / calcRadius);
 
-		// 圆心 = Origin + CircleOrigin 偏移（世界坐标系）
-		CoordStruct circleCenter = originPos;
-		if (!Data->CircleOrigin.IsEmpty())
+	// 圆心 = Origin + CircleOrigin 偏移（世界坐标系）
+	// CircleOrigin Z 高度规则：CircleOrigin 非空 → 绝对覆写 OriginFLH.Z+CircleOrigin.Z；
+	// 仅 OriginFLH 非空 → 相对偏移 _vectorAcquireZ+OriginFLH.Z
+	// 修改 CircleOrigin 的 Z 后再走 GetFLHAbsoluteCoords，tilt 对 F/L 分量的 Z 投影自动保留
+	CoordStruct adjustedCircleOrigin = Data->CircleOrigin;
+	if (!Data->CircleOrigin.IsEmpty())
+		adjustedCircleOrigin.Z = Data->OriginFLH.Z + Data->CircleOrigin.Z;
+	// else if (!Data->OriginFLH.IsEmpty())
+	//	adjustedCircleOrigin.Z = _vectorAcquireZ + Data->OriginFLH.Z;  // 废代码：adjustedCircleOrigin 后续不会被使用
+	// 注意：仅 OriginFLH 时 CircleOrigin 为空，不进入 GetFLHAbsoluteCoords 分支，
+	// 需要单独处理 Z（见下方 OriginFLH 偏移后覆盖）
+
+	CoordStruct circleCenter = originPos;
+
+	// AllowOriginTilt：用三维 FLH 旋转替代二维 GetFLHAbsoluteCoords
+	if (Data->AllowOriginTilt && !Data->OriginFLH.IsEmpty() && Data->Origin != VectorData::VectorOrigin::Self)
+	{
+		int f = Data->OriginFLH.X, l = Data->OriginFLH.Y, h = Data->OriginFLH.Z;
+		double sinT = std::sin(originTerrainTilt), cosT = std::cos(originTerrainTilt);
+		// FLH 旋转用单位自身 facing（_facingRad 是法向量方向，不适用于 FLH 的 F/L 分量）
+		TechnoClass* pOriginTechno = nullptr;
+		switch (Data->Origin)
 		{
-			if (Data->AllowOriginTilt)
-				circleCenter = GetFLHAbsoluteCoords(originPos, Data->CircleOrigin, mainFacingDir); // 官方API，不得修改
-			else
-				circleCenter = originPos + Data->CircleOrigin;
+		case VectorData::VectorOrigin::Target:
+			if (pBullet && pBullet->Target)
+				pOriginTechno = abstract_cast<TechnoClass*>(pBullet->Target);
+			else if (pTechno && pTechno->Target)
+				pOriginTechno = abstract_cast<TechnoClass*>(pTechno->Target);
+			break;
+		case VectorData::VectorOrigin::Source:
+			pOriginTechno = abstract_cast<TechnoClass*>(_pSource);
+			break;
+		case VectorData::VectorOrigin::Launcher:
+			pOriginTechno = abstract_cast<TechnoClass*>(_pLauncher);
+			break;
+		case VectorData::VectorOrigin::Self:
+			pOriginTechno = pTechno;
+			break;
 		}
+		double unitF = (pOriginTechno && !IsDeadOrInvisible(pOriginTechno))
+			? pOriginTechno->PrimaryFacing.Current().GetRadian() : 0.0;
+		double cosF = std::cos(unitF), sinF = std::sin(unitF);
+		// 先绕 L 轴（左右轴）转 tilt（俯仰），再绕 Z 轴转 facing
+		// tilt>0=头低屁股高，头部在 +F 方向偏下
+		// FLH=(f,l,h) 先 tilt: f'=f*cosT-h*sinT, l'=l, h'=f*sinT+h*cosT
+		// 再 facing: X=cosF*f'-sinF*l', Y=sinF*f'+cosF*l', Z=h'
+		double fTilt = f * cosT - h * sinT;
+		double hTilt = f * sinT + h * cosT;
+		circleCenter.X += static_cast<int>(fTilt * cosF - l * sinF);
+		circleCenter.Y += static_cast<int>(fTilt * sinF + l * cosF);
+		circleCenter.Z += static_cast<int>(hTilt);
+	}
+
+	if (!Data->CircleOrigin.IsEmpty())
+	{
+		if (Data->AllowOriginTilt)
+		{
+			// FLH→世界坐标（facing + terrainTilt 三维旋转），替换 GetFLHAbsoluteCoords（仅二维）
+			double cosF = std::cos(effectiveFacing), sinF = std::sin(effectiveFacing);
+			double cosT = std::cos(originTerrainTilt), sinT = std::sin(originTerrainTilt);
+			double f = static_cast<double>(adjustedCircleOrigin.X);
+			double l = static_cast<double>(adjustedCircleOrigin.Y);
+			double h = static_cast<double>(adjustedCircleOrigin.Z);
+			// 先绕 L 轴（左右轴）转 tilt（俯仰），再绕 Z 轴转 facing
+			double fTilt = f * cosT - h * sinT;
+			double hTilt = f * sinT + h * cosT;
+			circleCenter.X += static_cast<int>(fTilt * cosF - l * sinF);
+			circleCenter.Y += static_cast<int>(fTilt * sinF + l * cosF);
+			circleCenter.Z += static_cast<int>(hTilt);
+		}
+		else
+		{
+			circleCenter = originPos + adjustedCircleOrigin;
+		}
+	}
+	else if (!Data->OriginFLH.IsEmpty())
+	{
+		// 仅 OriginFLH：CircleOrigin 为空时不走 FLH 转换，手动设 Z
+		circleCenter.Z = _vectorAcquireZ + Data->OriginFLH.Z;
+	}
 
 		// 圆心移动：Vector.Origin.* 系统
 		if (!Data->OriginMoveTo.IsEmpty() || !Data->OriginTargetFLH.IsEmpty()
@@ -769,12 +898,6 @@ VectorResult VectorEffect::GetVectorResult()
 		_originElapsed++;
 	}
 
-	// Circle 圆心 Z 高度规则（OriginFLH 做相对偏移，CircleOrigin 做绝对覆写）
-	if (!Data->CircleOrigin.IsEmpty())
-		circleCenter.Z = Data->OriginFLH.Z + Data->CircleOrigin.Z;
-	else if (!Data->OriginFLH.IsEmpty())
-		circleCenter.Z = _vectorAcquireZ + Data->OriginFLH.Z;
-
 	// 圆心位移叠加：Circle 模式追踪圆心→调整 currentPos
 	CoordStruct centerDelta{ 0, 0, 0 };  // 初始化避免 C4701 警告
 	bool useCenterTracking = false;
@@ -798,7 +921,8 @@ VectorResult VectorEffect::GetVectorResult()
 	double dy = static_cast<double>(trackPos.Y - circleCenter.Y);
 	double dz = static_cast<double>(trackPos.Z - circleCenter.Z);
 		double currentDist;
-		bool useTiltPlane = hasNormal || (Data->AllowedTilt && effectiveTilt != 0.0);
+		bool useTiltPlane = hasNormal || (Data->AllowedTilt && effectiveTilt != 0.0)
+			|| (Data->AllowOriginTilt && originTerrainTilt != 0.0);
 		if (useTiltPlane)
 		{
 			// 倾斜圆面：投影到 LH 平面计算当前距离

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -727,12 +727,12 @@ VectorResult VectorEffect::GetVectorResult()
 				if (Data->OriginCircleMaxRadius > 0 && tr > Data->OriginCircleMaxRadius) tr = Data->OriginCircleMaxRadius;
 				if (Data->OriginCircleMinRadius > 0 && tr < Data->OriginCircleMinRadius) tr = Data->OriginCircleMinRadius;
 				// 角步长：优先线速度/半径推算，否则用固定角速度
-				double angleStep = Data->OriginCircleAnglePerStep;
+				double originAngleStep = Data->OriginCircleAnglePerStep;
 				if (_originCircleSpeed != 0 && tr > 0)
-					angleStep = Math::rad2deg(_originCircleSpeed / tr);
+					originAngleStep = Math::rad2deg(_originCircleSpeed / tr);
 				// Lissajous=yes: 累积大角旋转（增减边震荡），no: 每帧仅增量旋转（平滑行星）
-				_originCircleAngle += angleStep;
-				double r = Data->OriginLissajous ? Math::deg2rad(_originCircleAngle) : Math::deg2rad(angleStep);
+				_originCircleAngle += originAngleStep;
+				double r = Data->OriginLissajous ? Math::deg2rad(_originCircleAngle) : Math::deg2rad(originAngleStep);
 				double ca = std::cos(r), sa = std::sin(r);
 				// 当前圆心相对基座的偏移在 LH 平面投影
 				double dx = (double)_originOffset.X, dy = (double)_originOffset.Y, dz = (double)_originOffset.Z;

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -91,7 +91,9 @@ static bool TryGetSpawnManagerTarget(TechnoClass* pTechno, CoordStruct& out)
 
 // 目标缓存（挂在 TechnoStatus，归一目标保护机制）：
 // Techno 获得 Vector 时写入目标单位+格子（Spawn 从 SpawnManager/Kamikaze 取，普通单位记 Target）。
-// NoUpdate=yes 存一次即停，之后只读格子（目标死活不影响）；no 每帧刷新，目标死亡/无效（脚下格子）冻结最后有效值
+// NoUpdate=yes 存一次即停，之后只读格子（目标死活不影响）。
+// NoUpdate=no 只跟随缓存锁定的目标单位实时位置，不再读引擎参数（防引擎集结目标点污染）；
+// 锁定的是格子（无单位）则不刷新（格子不会移动）；目标死亡冻结最后有效格子
 void VectorEffect::CacheTargetNow()
 {
 	if (!pTechno)
@@ -100,10 +102,30 @@ void VectorEffect::CacheTargetNow()
 	if (!status)
 		return;
 
-	// NoUpdate=yes：第一笔（挂载时）已写入即停止刷新
-	if (Data->OriginNoUpdate && status->HasVectorTargetCache())
+	// --- 已有缓存：NoUpdate=no 只跟随锁定单位，不再读引擎参数 ---
+	if (status->HasVectorTargetCache())
+	{
+		// NoUpdate=yes：锁定第一笔，不刷新
+		if (Data->OriginNoUpdate)
+			return;
+		// NoUpdate=no：跟随锁定的单位实时位置
+		AbstractClass* pCachedTarget = status->GetVectorCachedTarget();
+		if (pCachedTarget)
+		{
+			TechnoClass* pTgt = abstract_cast<TechnoClass*>(pCachedTarget);
+			if (pTgt && !IsDeadOrInvisible(pTgt))
+			{
+				CoordStruct c = pTgt->GetCoords();
+				if (!IsSameCell(c, pTechno->GetCoords())) // 单位跑到导弹脚下（极罕见）防污染
+					status->SetVectorTargetCache(pCachedTarget, c);
+			}
+			// 目标死亡：不写，冻结最后有效格子
+		}
+		// 锁定的是格子（无单位）：格子不会移动，不刷新
 		return;
+	}
 
+	// --- 第一笔：引擎来源链取候选，优先单位 ---
 	AbstractClass* candTarget = nullptr;
 	CoordStruct candCell{};
 	bool got = false;

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -325,6 +325,30 @@ VectorResult VectorEffect::GetVectorResult()
 	result.FallingDestroyHeight = Data->FallingDestroyHeight;
 	result.AllowRotateUnit = Data->SyncFacing; // 成熟机制：单位端同步朝向，删改前确认
 
+	// Circle 预初始化：在 DisabledFrames 冻结前完成，保证首帧后参数可用
+	if (_elapsedFrames == 0)
+	{
+		_currentCircleSpeed = static_cast<double>(Data->CircleSpeed);
+		if (_currentCircleSpeed <= 0.0)
+		{
+			if (pBullet)
+				_currentCircleSpeed = pBullet->Speed;
+			else if (pTechno)
+				_currentCircleSpeed = pTechno->GetTechnoType()->Speed;
+		}
+		_currentCircleAngle = Data->CircleAnglePerStep;
+		if (Data->CircleRandomAngleMax > Data->CircleRandomAngleMin)
+		{
+			if (Data->CircleRandomAngleMax2 > Data->CircleRandomAngleMin2 && Random::RandomRanged(0, 1))
+				_currentCircleAngle = Data->CircleRandomAngleMin2 + (Data->CircleRandomAngleMax2 - Data->CircleRandomAngleMin2) * Random::RandomDouble();
+			else
+				_currentCircleAngle = Data->CircleRandomAngleMin + (Data->CircleRandomAngleMax - Data->CircleRandomAngleMin) * Random::RandomDouble();
+		}
+		_currentCircleRadius = static_cast<double>(Data->CircleRadius);
+		if (Data->CircleRandomRadiusMax > Data->CircleRandomRadiusMin)
+			_currentCircleRadius = Random::RandomRanged(Data->CircleRandomRadiusMin, Data->CircleRandomRadiusMax);
+	}
+
 	// DisabledFrames：首帧快照后冻结，不阻塞其他 AE，不计入运动时间
 	if (_elapsedFrames < Data->DisabledFrames)
 	{
@@ -624,37 +648,14 @@ VectorResult VectorEffect::GetVectorResult()
 			calcRadius = std::sqrt(tdx * tdx + tdy * tdy);
 		}
 
-		// 动态线速：首帧初始化，每帧叠加加速度
-		if (_elapsedFrames == 0)
-		{
-			_currentCircleSpeed = static_cast<double>(Data->CircleSpeed);
-			// 无速度参数时，兜底取抛射体/单位自身速度
-			if (_currentCircleSpeed <= 0.0)
-			{
-				if (pBullet)
-					_currentCircleSpeed = pBullet->Speed;
-				else if (pTechno)
-					_currentCircleSpeed = pTechno->GetTechnoType()->Speed;
-			}
-		}
+		// 动态线速：每帧叠加加速度（初始值已在 DisabledFrames 前预初始化）
 		_currentCircleSpeed += Data->CircleSpeedAcceleration;
 		if (Data->CircleMaxSpeed != 0 && _currentCircleSpeed > Data->CircleMaxSpeed)
 			_currentCircleSpeed = static_cast<double>(Data->CircleMaxSpeed);
 		if (Data->CircleMinSpeed != 0 && _currentCircleSpeed < Data->CircleMinSpeed)
 			_currentCircleSpeed = static_cast<double>(Data->CircleMinSpeed);
 
-		// 角速度动态：首帧初始化，每帧叠加加速度
-		if (_elapsedFrames == 0)
-		{
-			_currentCircleAngle = Data->CircleAnglePerStep;
-			if (Data->CircleRandomAngleMax > Data->CircleRandomAngleMin)
-		{
-			if (Data->CircleRandomAngleMax2 > Data->CircleRandomAngleMin2 && Random::RandomRanged(0, 1))
-				_currentCircleAngle = Data->CircleRandomAngleMin2 + (Data->CircleRandomAngleMax2 - Data->CircleRandomAngleMin2) * Random::RandomDouble();
-			else
-				_currentCircleAngle = Data->CircleRandomAngleMin + (Data->CircleRandomAngleMax - Data->CircleRandomAngleMin) * Random::RandomDouble();
-		}
-		}
+		// 角速度动态：每帧叠加加速度（初始值已在 DisabledFrames 前预初始化）
 		_currentCircleAngle += Data->CircleAngleAcceleration;
 		if (Data->CircleMaxAngle != 0.0 && _currentCircleAngle > Data->CircleMaxAngle)
 			_currentCircleAngle = Data->CircleMaxAngle;

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -166,12 +166,16 @@ void VectorEffect::OnStart()
 			DirStruct bulletFacing;
 			bulletFacing.SetValue(static_cast<short>(bulletRad * 32768.0 / M_PI));
 			_initialOriginPos = GetFLHAbsoluteCoords(pBullet->GetCoords(), Data->OriginFLH, bulletFacing);
+			_facingDir = bulletFacing; // 锁定初始朝向
+			_facingRad = _facingDir.GetRadian();
 		}
 		else if (pTechno)
 		{
 			CoordStruct unitPos = pTechno->GetCoords();
 			DirStruct unitFacing = pTechno->TurretFacing().Current();
 			_initialOriginPos = GetFLHAbsoluteCoords(unitPos, Data->OriginFLH, unitFacing);
+			_facingDir = unitFacing; // 锁定初始朝向
+			_facingRad = _facingDir.GetRadian();
 		}
 		break;
 	}
@@ -238,7 +242,10 @@ void VectorEffect::OnStart()
 		{
 			TechnoClass* pLauncherTechno = abstract_cast<TechnoClass*>(_pLauncher);
 			if (pLauncherTechno && !IsDeadOrInvisible(pLauncherTechno))
-				_facingRad = pLauncherTechno->TurretFacing().Current().GetRadian();
+			{
+				_facingDir = pLauncherTechno->TurretFacing().Current(); // 直接存 DirStruct，不经 GetRadian 往返
+				_facingRad = _facingDir.GetRadian();
+			}
 		}
 		break;
 	}
@@ -295,23 +302,6 @@ void VectorEffect::OnStart()
 		break;
 	}
 	}
-
-	// === DEBUG: Origin=Target coordinate diagnostics ===
-	{
-		const char* originStr = "Unknown";
-		switch (Data->Origin)
-		{
-		case VectorData::VectorOrigin::Target:  originStr = "Target";  break;
-		case VectorData::VectorOrigin::Launcher:originStr = "Launcher";break;
-		case VectorData::VectorOrigin::Source:  originStr = "Source";  break;
-		case VectorData::VectorOrigin::Self:    originStr = "Self";    break;
-		default:                                originStr = "FLH";     break;
-		}
-		Debug::Log("[VectorOnStart] Origin=%s NoUpdate=%d IsOnWorld=%d\n", originStr, (int)Data->OriginNoUpdate, (int)Data->OriginIsOnWorld);
-		Debug::Log("  _initialOriginPos = (%d, %d, %d)\n", _initialOriginPos.X, _initialOriginPos.Y, _initialOriginPos.Z);
-		Debug::Log("  _facingRad        = %.4f rad  (%.1f deg)\n", _facingRad, _facingRad * 180.0 / M_PI);
-	}
-	// === END DEBUG ===
 }
 
 VectorResult VectorEffect::GetVectorResult()
@@ -342,6 +332,7 @@ VectorResult VectorEffect::GetVectorResult()
 		AdvanceFrame();
 		return result;
 	}
+
 
 	// ========================================================================
 	// Freeze — 成熟机制，别乱动
@@ -477,18 +468,12 @@ VectorResult VectorEffect::GetVectorResult()
 	double effectiveFacing = _facingRad;
 	double effectiveTilt = _tiltRad;
 	DirStruct mainFacingDir = Radians2Dir(effectiveFacing); // 官方API，不得修改：引擎弧度→DirStruct转换
-	// OriginNoUpdate + Target/Source：直接用 OnStart 的 Point2Dir 结果，不经 GetRadian→Radians2Dir 往返
-	if (Data->OriginNoUpdate && (Data->Origin == VectorData::VectorOrigin::Target || Data->Origin == VectorData::VectorOrigin::Source))
+	// OriginNoUpdate + Target/Source/Launcher/Self：直接用 OnStart 存的 DirStruct，不经 GetRadian→Radians2Dir 往返
+	if (Data->OriginNoUpdate && (Data->Origin == VectorData::VectorOrigin::Target || Data->Origin == VectorData::VectorOrigin::Source || Data->Origin == VectorData::VectorOrigin::Launcher || Data->Origin == VectorData::VectorOrigin::Self))
 	{
 		mainFacingDir = _facingDir;
 		effectiveFacing = _facingDir.GetRadian();
-		Debug::Log("[VectorMFD_override] _facingDir.Raw=%u  mainFacingDir.Raw=%u  GetRadian=%.4f\n",
-			(unsigned)_facingDir.Raw, (unsigned)mainFacingDir.Raw, mainFacingDir.GetRadian());
 	}
-	Debug::Log("[VectorMFD_init] effectiveFacing=%.4f rad (%.1f deg)  raw=%-5u  GetRadian=%.4f rad (%.1f deg)\n",
-		effectiveFacing, effectiveFacing * 180.0 / M_PI,
-		(unsigned)mainFacingDir.Raw,
-		mainFacingDir.GetRadian(), mainFacingDir.GetRadian() * 180.0 / M_PI);
 
 	// OriginIsOnWorld：锁定世界坐标系（朝北），覆盖 Origin 朝向
 	if (Data->OriginIsOnWorld)
@@ -1381,6 +1366,8 @@ VectorResult VectorEffect::GetVectorResult()
 		{
 			if (Data->OriginIsOnWorld)
 				frameTarget = GetFLHAbsoluteCoords(originPos, frameTargetFlh, DirStruct{}); // 世界坐标系，无视倾斜
+			else if (Data->OriginNoUpdate)
+				frameTarget = GetFLHAbsoluteCoords(originPos, frameTargetFlh, mainFacingDir); // 锁定原点
 			else
 				frameTarget = GetFLHAbsoluteCoords(currentPos, frameTargetFlh, Facing(pBullet, currentPos)); // 官方API，不得修改
 		}
@@ -1392,21 +1379,6 @@ VectorResult VectorEffect::GetVectorResult()
 		break;
 	}
 
-	// === DEBUG: frameTarget (first 5 movement frames) ===
-	if (_movementFrames <= 5)
-	{
-		double mfdRad = mainFacingDir.GetRadian();
-		double mfdDeg = mfdRad * 180.0 / M_PI;
-		Debug::Log("[VectorFrame%d] TargetFLH=(%d,%d,%d) mainFacingDir raw=%-5u r=%.4f deg=%.1f\n",
-			_movementFrames, Data->TargetFLH.X, Data->TargetFLH.Y, Data->TargetFLH.Z,
-			(unsigned)mainFacingDir.Raw, mfdRad, mfdDeg);
-		Debug::Log("  currentPos  = (%d, %d, %d)\n", currentPos.X, currentPos.Y, currentPos.Z);
-		Debug::Log("  originPos   = (%d, %d, %d)\n", originPos.X, originPos.Y, originPos.Z);
-		Debug::Log("  frameTarget = (%d, %d, %d)\n", frameTarget.X, frameTarget.Y, frameTarget.Z);
-	}
-	// === END DEBUG ===
-
-	// --- 方向向量 ---
 	CoordStruct dirVec;
 	dirVec.X = frameTarget.X - currentPos.X;
 	dirVec.Y = frameTarget.Y - currentPos.Y;

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -218,7 +218,7 @@ void VectorEffect::OnStart()
 			// 消费端 GetFLHAbsoluteOffset 世界角 = -(mainFacingDir + flhAngle)，要求 = 近交点角 + deg：
 			// flhAngle = -mainFacingDirSim - β - deg
 			//   β = atan2 近交点世界角（目标点指向抛射体）
-			//   mainFacingDirSim = 复刻消费端取值：NoUpdate=yes 用 DirStruct 原值(α)，no 用 Radians2Dir(α)（差 90°）
+			//   mainFacingDirSim = 消费端 mainFacingDir 统一取 DirStruct 原值（NoUpdate 不影响坐标系）
 			double flhAngle;
 			bool hasAngleRange = (Data->TargetOffsetAngleMin < Data->TargetOffsetAngleMax)
 				|| (Data->TargetOffsetAngleMin2 < Data->TargetOffsetAngleMax2);
@@ -252,9 +252,8 @@ void VectorEffect::OnStart()
 				{
 					double beta = std::atan2(bulletPos.Y - targetPos.Y, bulletPos.X - targetPos.X); // 近交点世界角
 					double alpha = Point2Dir(targetPos, bulletPos).GetRadian(); // 近交点 DirStruct 角
-					double mainFacingDirSim = Data->OriginNoUpdate
-						? alpha
-						: Radians2Dir(alpha).GetRadian(); // 复刻消费端 mainFacingDir 取值路径
+					// 消费端 mainFacingDir 统一取 DirStruct 原值（NoUpdate 不影响坐标系），直接复刻
+					double mainFacingDirSim = alpha;
 					flhAngle = -mainFacingDirSim - beta - Math::deg2rad(deg);
 				}
 				else
@@ -370,14 +369,14 @@ void VectorEffect::OnStart()
 	switch (Data->Origin)
 	{
 	case VectorData::VectorOrigin::Target:
-		if (Data->OriginNoUpdate)
-		{
+		// 无论 NoUpdate 都锁定基线（OnStart 时引擎目标还是真实的）：NoUpdate=yes 直接用它，
+		// no 每帧刷新覆盖；引擎目标失效时回退此基线（保证打地面轨迹一致）
 		// 锚点 = 引擎 Kamikaze 控制器存的目标点（Homing 更新/引擎写入，目标死亡冻结）→ 攻击目标 → 自身
 		if (pTechno)
 		{
 			CoordStruct kamikazePos{};
 			bool gotKamikaze = TryGetKamikazeTarget(pTechno, kamikazePos);
-			// ① TechnoStatus 目标缓存（挂载时固化；NoUpdate=yes 只读格子，目标死活不影响）
+			// ① TechnoStatus 目标缓存（挂载时固化；只读格子，目标死活不影响）
 			TechnoStatus* cacheStatus = GetStatus<TechnoExt, TechnoStatus>(pTechno);
 			if (cacheStatus && cacheStatus->HasVectorTargetCache())
 			{
@@ -410,7 +409,6 @@ void VectorEffect::OnStart()
 			{
 				_initialOriginPos = pObject->GetCoords();
 			}
-		}
 		break;
 
 	case VectorData::VectorOrigin::Launcher:
@@ -579,6 +577,7 @@ void VectorEffect::OnStart()
 		break;
 	}
 	}
+
 }
 
 VectorResult VectorEffect::GetVectorResult()
@@ -784,8 +783,17 @@ VectorResult VectorEffect::GetVectorResult()
 	double effectiveFacing = _facingRad;
 	double effectiveTilt = _tiltRad;
 	DirStruct mainFacingDir = Radians2Dir(effectiveFacing); // 官方API，不得修改：引擎弧度→DirStruct转换
-	// OriginNoUpdate + Target/Source/Launcher/Self：直接用 OnStart 存的 DirStruct，不经 GetRadian→Radians2Dir 往返
-	if (Data->OriginNoUpdate && (Data->Origin == VectorData::VectorOrigin::Target || Data->Origin == VectorData::VectorOrigin::Source || Data->Origin == VectorData::VectorOrigin::Launcher || Data->Origin == VectorData::VectorOrigin::Self))
+	// Target/Source/Launcher/Self：统一用 OnStart 存的 DirStruct 作基础朝向。
+	// Radians2Dir(GetRadian()) 往返存在 90° 偏置（BINARY_ANGLE_MAGIC 为负），
+	// NoUpdate=no 时误走该路径导致坐标系旋转。NoUpdate 只决定原点是否动态刷新，不影响坐标系计算。
+	bool hasNormal = !Data->NormalVector.IsEmpty()
+		|| Data->NormalRandomF.Y > Data->NormalRandomF.X
+		|| Data->NormalRandomL.Y > Data->NormalRandomL.X
+		|| Data->NormalRandomH.Y > Data->NormalRandomH.X;
+	if (!hasNormal && (Data->Origin == VectorData::VectorOrigin::Target
+		|| Data->Origin == VectorData::VectorOrigin::Source
+		|| Data->Origin == VectorData::VectorOrigin::Launcher
+		|| Data->Origin == VectorData::VectorOrigin::Self))
 	{
 		mainFacingDir = _facingDir;
 		effectiveFacing = _facingDir.GetRadian();
@@ -799,16 +807,14 @@ VectorResult VectorEffect::GetVectorResult()
 		effectiveTilt = 0.0;
 	}
 
-	bool hasNormal = !Data->NormalVector.IsEmpty()
-		|| Data->NormalRandomF.Y > Data->NormalRandomF.X
-		|| Data->NormalRandomL.Y > Data->NormalRandomL.X
-		|| Data->NormalRandomH.Y > Data->NormalRandomH.X;
-	if (!Data->OriginNoUpdate && !hasNormal && !Data->AllowOriginTilt && !Data->OriginIsOnWorld)
+	// 统一朝向算法：NoUpdate 只切换计算点（锁定 _initialOriginPos vs 实时坐标），不切换坐标系/朝向算法
+	if (!hasNormal && !Data->AllowOriginTilt && !Data->OriginIsOnWorld)
 	{
 		switch (Data->Origin)
 		{
 		case VectorData::VectorOrigin::Source:
-			if (_pSource && !IsDeadOrInvisible(_pSource))
+			// 计算点：NoUpdate=yes 用锁定值，no 每帧刷新
+			if (!Data->OriginNoUpdate && _pSource && !IsDeadOrInvisible(_pSource))
 			{
 				_initialOriginPos = _pSource->GetCoords(); // 来源活着：每帧更新快照
 			}
@@ -829,42 +835,46 @@ VectorResult VectorEffect::GetVectorResult()
 			bool isGround = (pBullet && !abstract_cast<TechnoClass*>(pBullet->Target));
 			if (isGround && _movementFrames > 1)
 				break;
-			// 允许更新（NoUpdate=no）：缓存优先（每帧已刷新，目标死亡冻结），缓存空回退引擎来源
+			// 计算点：默认锁定值起步，NoUpdate=no 才走缓存/引擎链动态获取
 			CoordStruct targetPos = _initialOriginPos;
 			bool gotTarget = !targetPos.IsEmpty();
-			if (pTechno)
+			if (!Data->OriginNoUpdate)
 			{
-				if (TechnoStatus* status = GetStatus<TechnoExt, TechnoStatus>(pTechno))
+				// 允许更新（NoUpdate=no）：缓存优先（每帧已刷新，目标死亡冻结），缓存空回退引擎来源
+				if (pTechno)
 				{
-					if (status->HasVectorTargetCache())
+					if (TechnoStatus* status = GetStatus<TechnoExt, TechnoStatus>(pTechno))
 					{
-						targetPos = status->GetVectorCachedCell();
-						gotTarget = true;
+						if (status->HasVectorTargetCache())
+						{
+							targetPos = status->GetVectorCachedCell();
+							gotTarget = true;
+						}
 					}
 				}
-			}
-			if (!gotTarget && pBullet && pBullet->Target)
-			{
-				targetPos = pBullet->Target->GetCoords(); // 抛射体目标 Cell 是真实落点
-				gotTarget = true;
-			}
-			else if (!gotTarget && pBullet)
-			{
-				targetPos = pBullet->TargetCoords;
-				gotTarget = true;
-			}
-			else if (!gotTarget && pTechno && pTechno->Target)
-			{
-				targetPos = pTechno->Target->GetCoords();
-				gotTarget = true;
-			}
-			else if (!gotTarget && pTechno)
-			{
-				CoordStruct kamikazePos{};
-				if (TryGetKamikazeTarget(pTechno, kamikazePos) || TryGetSpawnManagerTarget(pTechno, kamikazePos))
+				if (!gotTarget && pBullet && pBullet->Target)
 				{
-					targetPos = kamikazePos;
+					targetPos = pBullet->Target->GetCoords(); // 抛射体目标 Cell 是真实落点
 					gotTarget = true;
+				}
+				else if (!gotTarget && pBullet)
+				{
+					targetPos = pBullet->TargetCoords;
+					gotTarget = true;
+				}
+				else if (!gotTarget && pTechno && pTechno->Target)
+				{
+					targetPos = pTechno->Target->GetCoords();
+					gotTarget = true;
+				}
+				else if (!gotTarget && pTechno)
+				{
+					CoordStruct kamikazePos{};
+					if (TryGetKamikazeTarget(pTechno, kamikazePos) || TryGetSpawnManagerTarget(pTechno, kamikazePos))
+					{
+						targetPos = kamikazePos;
+						gotTarget = true;
+					}
 				}
 			}
 			if (gotTarget)
@@ -1658,7 +1668,8 @@ VectorResult VectorEffect::GetVectorResult()
 				double tLenXY = std::sqrt(tdx * tdx + tdy * tdy);
 				if (tLenXY > 1e-6)
 				{
-					moveDir = Radians2Dir(std::atan2(tdy, tdx)); // 官方API，不得修改
+					// 与 AutoWeapon IsOnTarget 同款：Point2Dir 内部处理 RA2 坐标系（裸 atan2+Radians2Dir 有 90° 偏置）
+					moveDir = Point2Dir(currentPos, tgt); // 抛射体→目标 连线方向
 					if (Data->AllowCircleTilt)
 					{
 						double tLen3D = std::sqrt(tdx * tdx + tdy * tdy + tdz * tdz);
@@ -1675,7 +1686,8 @@ VectorResult VectorEffect::GetVectorResult()
 			if (_elapsedFrames == 0)
 				_currentAngle = 0.0;
 			_currentAngle += Data->AnglePerStep;
-			moveDir = Radians2Dir(moveDir.GetRadian() + Math::deg2rad(_currentAngle)); // 官方API，不得修改
+			// SetRadian 与 GetRadian 互逆（Radians2Dir 往返存在 90° 偏置，不能用）
+			moveDir.SetRadian(moveDir.GetRadian() + Math::deg2rad(_currentAngle));
 		}
 
 		CoordStruct grow = { static_cast<int>(Data->GrowRate.X * _movementFrames),
@@ -1719,44 +1731,33 @@ VectorResult VectorEffect::GetVectorResult()
 	frameTargetFlh.Y = Data->TargetFLH.Y + _randomTargetOffset.Y;
 	frameTargetFlh.Z = Data->TargetFLH.Z + _randomTargetOffset.Z;
 
-	// TargetFLH → 世界坐标：照搬 AutoWeapon/AttachFire 的成熟管线
-	// 官方API，不得修改：Techno 路径走 Locomotor 矩阵，非Techno 路径走 Point2Dir+GetFLHAbsoluteCoords
+	// TargetFLH → 世界坐标：AutoWeapon 同款管线
+	// 坐标系统一：矩阵偏移（含 IsOnTurret 炮塔/车身）+ NoUpdate 控制的计算点 originPos
 	CoordStruct frameTarget;
-	bool isOnTurret = !Data->OriginIsOnBody;
+	bool isOnTurret = !Data->OriginIsOnBody; // AutoWeapon 语义：yes=炮塔指向，no=车身指向
 	switch (Data->Origin)
 	{
 	case VectorData::VectorOrigin::Launcher:
 		{
-			if (Data->OriginNoUpdate)
-				frameTarget = GetFLHAbsoluteCoords(originPos, frameTargetFlh, mainFacingDir); // 锁定原点
-			else
+			TechnoClass* pLT = abstract_cast<TechnoClass*>(_pLauncher);
+			if (pLT && !IsDeadOrInvisible(pLT))
 			{
-				TechnoClass* pLT = abstract_cast<TechnoClass*>(_pLauncher);
-				if (pLT && !IsDeadOrInvisible(pLT))
-					frameTarget = GetFLHAbsoluteCoords(pLT, frameTargetFlh, isOnTurret); // 官方API，不得修改
-				else
-					frameTarget = GetFLHAbsoluteCoords(originPos, frameTargetFlh, mainFacingDir); // 官方API，不得修改
+				// AutoWeapon 同款：Locomotor 矩阵 + TurretOffset + 炮塔旋转角
+				CoordStruct mtxPos = GetFLHAbsoluteCoords(pLT, frameTargetFlh, isOnTurret);
+				frameTarget = originPos + (mtxPos - pLT->GetCoords());
 			}
+			else
+				frameTarget = GetFLHAbsoluteCoords(originPos, frameTargetFlh, mainFacingDir); // 官方API，不得修改
 		}
 		break;
 	case VectorData::VectorOrigin::Self:
-		if (pTechno)
+		if (Data->OriginIsOnWorld)
+			frameTarget = GetFLHAbsoluteCoords(originPos, frameTargetFlh, DirStruct{}); // 世界坐标系，无视倾斜
+		else if (pTechno)
 		{
-			if (Data->OriginIsOnWorld)
-				frameTarget = GetFLHAbsoluteCoords(originPos, frameTargetFlh, DirStruct{}); // 世界坐标系，无视倾斜
-			else if (Data->OriginNoUpdate)
-				frameTarget = GetFLHAbsoluteCoords(originPos, frameTargetFlh, mainFacingDir); // 锁定原点
-			else
-				frameTarget = GetFLHAbsoluteCoords(pTechno, frameTargetFlh, isOnTurret); // 官方API，不得修改
-		}
-		else if (pBullet)
-		{
-			if (Data->OriginIsOnWorld)
-				frameTarget = GetFLHAbsoluteCoords(originPos, frameTargetFlh, DirStruct{}); // 世界坐标系，无视倾斜
-			else if (Data->OriginNoUpdate)
-				frameTarget = GetFLHAbsoluteCoords(originPos, frameTargetFlh, mainFacingDir); // 锁定原点
-			else
-				frameTarget = GetFLHAbsoluteCoords(currentPos, frameTargetFlh, Facing(pBullet, currentPos)); // 官方API，不得修改
+			// AutoWeapon 同款：Locomotor 矩阵 + TurretOffset + 炮塔旋转角
+			CoordStruct mtxPos = GetFLHAbsoluteCoords(pTechno, frameTargetFlh, isOnTurret);
+			frameTarget = originPos + (mtxPos - pTechno->GetCoords());
 		}
 		else
 			frameTarget = GetFLHAbsoluteCoords(originPos, frameTargetFlh, mainFacingDir); // 官方API，不得修改

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -1148,8 +1148,10 @@ VectorResult VectorEffect::GetVectorResult()
 	}
 	_prevCircleCenter = circleCenter;
 
-	// 旋转当前方向向量并按目标半径缩放（追踪模式下调整 currentPos）
-	CoordStruct trackPos = currentPos;
+	// 圆上目标基于内部跟踪位置（非 currentPos），避免与 MoveTo 等 AE 的位移打架
+	if (_circlePos.IsEmpty())
+		_circlePos = currentPos;
+	CoordStruct trackPos = _circlePos;
 	if (useCenterTracking)
 	{
 		trackPos.X += centerDelta.X;
@@ -1210,9 +1212,9 @@ VectorResult VectorEffect::GetVectorResult()
 			double ndH = (dH / curDist * targetRadius);
 			double rL = ndL * cosA - ndH * sinA;
 			double rH = ndL * sinA + ndH * cosA;
-			result.MoveDisp.X = circleCenter.X + static_cast<int>(rL * (-sinF) + rH * (-cosF * sinT)) - currentPos.X;
-			result.MoveDisp.Y = circleCenter.Y + static_cast<int>(rL * cosF + rH * (-sinF * sinT)) - currentPos.Y;
-			result.MoveDisp.Z = circleCenter.Z + static_cast<int>(rH * cosT) - currentPos.Z;
+			result.MoveDisp.X = circleCenter.X + static_cast<int>(rL * (-sinF) + rH * (-cosF * sinT)) - _circlePos.X;
+			result.MoveDisp.Y = circleCenter.Y + static_cast<int>(rL * cosF + rH * (-sinF * sinT)) - _circlePos.Y;
+			result.MoveDisp.Z = circleCenter.Z + static_cast<int>(rH * cosT) - _circlePos.Z;
 		}
 		else
 		{
@@ -1221,11 +1223,14 @@ VectorResult VectorEffect::GetVectorResult()
 			double ndy = (dy / currentDist * targetRadius);
 			double rx = ndx * cosA - ndy * sinA;
 			double ry = ndx * sinA + ndy * cosA;
-			result.MoveDisp.X = circleCenter.X + static_cast<int>(rx) - currentPos.X;
-			result.MoveDisp.Y = circleCenter.Y + static_cast<int>(ry) - currentPos.Y;
+			result.MoveDisp.X = circleCenter.X + static_cast<int>(rx) - _circlePos.X;
+			result.MoveDisp.Y = circleCenter.Y + static_cast<int>(ry) - _circlePos.Y;
 			result.MoveDisp.Z = Data->CircleOrigin.IsEmpty() && Data->OriginFLH.IsEmpty()
-				? 0 : circleCenter.Z - currentPos.Z;  // 有显式高度指定时拉 Z，否则维持抛射体自身高度
+				? 0 : circleCenter.Z - _circlePos.Z;  // 有显式高度指定时拉 Z，否则维持抛射体自身高度
 		}
+		_circlePos.X += result.MoveDisp.X;
+		_circlePos.Y += result.MoveDisp.Y;
+		_circlePos.Z += result.MoveDisp.Z;
 		result.Force = true;
 
 		// 到达边界时结束 AE

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -879,27 +879,62 @@ VectorResult VectorEffect::GetVectorResult()
 	// ========================================================================
 	if (!Data->MoveTo.IsEmpty())
 	{
-		// moveDir：使用引擎 DirStruct，AnglePerStep 非零时叠加自旋角度
 		DirStruct moveDir = mainFacingDir;
+		double useCosT = 1.0, useSinT = 0.0;
+		bool hasTilt = (effectiveTilt != 0.0);
+
+		// Origin=Target：F 轴应以 抛射体→目标 连线为准（含 Z 落差），而非全局的 target→抛射体
+		if (Data->Origin == VectorData::VectorOrigin::Target)
+		{
+			CoordStruct tgt;
+			bool hasTgt = false;
+			if (pBullet && pBullet->Target)
+				{ tgt = pBullet->Target->GetCoords(); hasTgt = true; }
+			else if (pBullet)
+				{ tgt = pBullet->TargetCoords; hasTgt = true; }
+			else if (pTechno && pTechno->Target)
+				{ tgt = pTechno->Target->GetCoords(); hasTgt = true; }
+			if (hasTgt)
+			{
+				double tdx = static_cast<double>(tgt.X - currentPos.X);
+				double tdy = static_cast<double>(tgt.Y - currentPos.Y);
+				double tdz = static_cast<double>(tgt.Z - currentPos.Z);
+				double tLenXY = std::sqrt(tdx * tdx + tdy * tdy);
+				if (tLenXY > 1e-6)
+				{
+					moveDir = Radians2Dir(std::atan2(tdy, tdx)); // 官方API，不得修改
+					if (Data->AllowedTilt)
+					{
+						double tLen3D = std::sqrt(tdx * tdx + tdy * tdy + tdz * tdz);
+						useCosT = tLenXY / tLen3D;
+						useSinT = tdz / tLen3D;
+						hasTilt = true;
+					}
+				}
+			}
+		}
+
 		if (Data->AnglePerStep != 0.0)
 		{
 			if (_elapsedFrames == 0)
 				_currentAngle = 0.0;
 			_currentAngle += Data->AnglePerStep;
-			moveDir = Radians2Dir(mainFacingDir.GetRadian() + Math::deg2rad(_currentAngle)); // 官方API，不得修改
+			moveDir = Radians2Dir(moveDir.GetRadian() + Math::deg2rad(_currentAngle)); // 官方API，不得修改
 		}
+
 		CoordStruct grow = { static_cast<int>(Data->GrowRate.X * _movementFrames),
 			static_cast<int>(Data->GrowRate.Y * _movementFrames),
 			static_cast<int>(Data->GrowRate.Z * _movementFrames) };
 		CoordStruct moveFlh = Data->MoveTo + grow;
 
-		result.MoveDisp = GetFLHAbsoluteOffset(moveFlh, moveDir); // 官方API，不得修改
-		// 坐标轴倾斜：Tilt 非零时覆盖 Z 轴，使 FLH 位移沿倾斜坐标轴方向
-		if (effectiveTilt != 0.0)
+		if (hasTilt)
 		{
 			double mf = moveDir.GetRadian();
 			double cosF = std::cos(mf), sinF = std::sin(mf);
-			double cosT = std::cos(effectiveTilt), sinT = std::sin(effectiveTilt);
+			double cosT = (Data->Origin == VectorData::VectorOrigin::Target && Data->AllowedTilt)
+				? useCosT : std::cos(effectiveTilt);
+			double sinT = (Data->Origin == VectorData::VectorOrigin::Target && Data->AllowedTilt)
+				? useSinT : std::sin(effectiveTilt);
 			double F = static_cast<double>(moveFlh.X);
 			double L = static_cast<double>(moveFlh.Y);
 			double H = static_cast<double>(moveFlh.Z);
@@ -907,6 +942,11 @@ VectorResult VectorEffect::GetVectorResult()
 			result.MoveDisp.Y = static_cast<int>(F * sinF * cosT + L * cosF + H * (-sinF * sinT));
 			result.MoveDisp.Z = static_cast<int>(F * sinT + H * cosT);
 		}
+		else
+		{
+			result.MoveDisp = GetFLHAbsoluteOffset(moveFlh, moveDir); // 官方API，不得修改
+		}
+
 		result.Force = true;
 
 		AdvanceFrame();

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -4,6 +4,7 @@
 
 #include <Kamikaze.h>
 #include <SpawnManagerClass.h>
+#include <RocketLocomotionClass.h>
 
 #include <Ext/Helper/Scripts.h>
 #include <Ext/Helper/Status.h>
@@ -25,23 +26,6 @@
 // ========================================================================
 // 目标有效性辅助（SpawnMissile 场景专用）
 // ========================================================================
-
-// 两点是否同一格子（256 lepton = 1 格，坐标 >>8 得格子号，仅 XY）
-static bool IsSameCell(CoordStruct a, CoordStruct b)
-{
-	return (a.X >> 8) == (b.X >> 8)
-		&& (a.Y >> 8) == (b.Y >> 8);
-}
-
-// 脚下格子通用过滤（默认全跳）：任何目标坐标与自身同格都视为无效。
-// 引擎两种场景会把导弹目标设成自身脚下格子——spawn 未全部出生前的占位目标、
-// 目标死亡后的重置（MissileHoming）。两种都不该被 Vector 采用，一律跳过。
-static bool IsSelfCellTarget(TechnoClass* pTechno, AbstractClass* pTarget)
-{
-	if (!pTarget)
-		return true;
-	return IsSameCell(pTarget->GetCoords(), pTechno->GetCoords());
-}
 
 // 从引擎 Kamikaze 控制器读导弹的目标点（现有基建，不自己造轮子）：
 // KamikazeControl->Cell 存目标格子——Homing 开启时每帧更新（目标活着跟随、死亡冻结），
@@ -108,16 +92,14 @@ void VectorEffect::CacheTargetNow()
 		// NoUpdate=yes：锁定第一笔，不刷新
 		if (Data->OriginNoUpdate)
 			return;
-		// NoUpdate=no：跟随锁定的单位实时位置
+		// NoUpdate=no：跟随锁定的单位实时位置（目标在导弹脚下也正常更新——真实目标就该下坠去打）
 		AbstractClass* pCachedTarget = status->GetVectorCachedTarget();
 		if (pCachedTarget)
 		{
 			TechnoClass* pTgt = abstract_cast<TechnoClass*>(pCachedTarget);
 			if (pTgt && !IsDeadOrInvisible(pTgt))
 			{
-				CoordStruct c = pTgt->GetCoords();
-				if (!IsSameCell(c, pTechno->GetCoords())) // 单位跑到导弹脚下（极罕见）防污染
-					status->SetVectorTargetCache(pCachedTarget, c);
+				status->SetVectorTargetCache(pCachedTarget, pTgt->GetCoords());
 			}
 			// 目标死亡：不写，冻结最后有效格子
 		}
@@ -137,12 +119,10 @@ void VectorEffect::CacheTargetNow()
 		if (pTechno->SpawnOwner->Target)
 		{
 			TechnoClass* pTgt = abstract_cast<TechnoClass*>(pTechno->SpawnOwner->Target);
-			CoordStruct c = pTechno->SpawnOwner->Target->GetCoords();
-			if (!IsSameCell(c, pTechno->GetCoords())
-				&& (!pTgt || !IsDeadOrInvisible(pTgt))) // 非 Techno 目标（格子）不做死亡判断
+			if (!pTgt || !IsDeadOrInvisible(pTgt)) // 非 Techno 目标（格子）不做死亡判断
 			{
 				candTarget = pTechno->SpawnOwner->Target;
-				candCell = c;
+				candCell = pTechno->SpawnOwner->Target->GetCoords();
 				got = true;
 			}
 		}
@@ -151,41 +131,35 @@ void VectorEffect::CacheTargetNow()
 		if (!got && pSM && pSM->Target)
 		{
 			TechnoClass* pTgt = abstract_cast<TechnoClass*>(pSM->Target);
-			CoordStruct c = pSM->Target->GetCoords();
-			if (!IsSameCell(c, pTechno->GetCoords())
-				&& (!pTgt || !IsDeadOrInvisible(pTgt))) // 非 Techno 目标（格子）不做死亡判断
+			if (!pTgt || !IsDeadOrInvisible(pTgt)) // 非 Techno 目标（格子）不做死亡判断
 			{
 				candTarget = pSM->Target;
-				candCell = c;
+				candCell = pSM->Target->GetCoords();
 				got = true;
 			}
 		}
 		if (!got && pSM && pSM->Destination)
 		{
-			CoordStruct c = pSM->Destination->GetCoords();
-			if (!IsSameCell(c, pTechno->GetCoords()))
-			{
-				candCell = c;
-				got = true;
-			}
+			candCell = pSM->Destination->GetCoords();
+			got = true;
 		}
 		if (!got)
 		{
 			CoordStruct kamikazePos{};
-			if (TryGetKamikazeTarget(pTechno, kamikazePos) && !IsSameCell(kamikazePos, pTechno->GetCoords()))
+			if (TryGetKamikazeTarget(pTechno, kamikazePos))
 			{
 				candCell = kamikazePos;
 				got = true;
 			}
 		}
-		if (!got && pTechno->Target && !IsSelfCellTarget(pTechno, pTechno->Target))
+		if (!got && pTechno->Target)
 		{
 			candTarget = pTechno->Target;
 			candCell = pTechno->Target->GetCoords();
 			got = true;
 		}
 	}
-	else if (pTechno->Target && !IsSelfCellTarget(pTechno, pTechno->Target))
+	else if (pTechno->Target)
 	{
 		// 普通单位：直接记 Target
 		TechnoClass* pTgt = abstract_cast<TechnoClass*>(pTechno->Target);
@@ -197,7 +171,7 @@ void VectorEffect::CacheTargetNow()
 		}
 	}
 
-	// 有效才写；无效（取不到/脚下格子/目标死亡）不写，保留最后有效值（冻结）
+	// 有效才写；取不到/目标死亡不写，保留最后有效值（冻结）
 	if (got)
 		status->SetVectorTargetCache(candTarget, candCell);
 }
@@ -398,31 +372,29 @@ void VectorEffect::OnStart()
 	case VectorData::VectorOrigin::Target:
 		if (Data->OriginNoUpdate)
 		{
-			// 锚点 = 引擎 Kamikaze 控制器存的目标点（Homing 更新/引擎写入，目标死亡冻结）→ 攻击目标 → 自身
-			// 脚下格子（引擎占位/重置污染）默认全跳
-			if (pTechno)
+		// 锚点 = 引擎 Kamikaze 控制器存的目标点（Homing 更新/引擎写入，目标死亡冻结）→ 攻击目标 → 自身
+		if (pTechno)
+		{
+			CoordStruct kamikazePos{};
+			bool gotKamikaze = TryGetKamikazeTarget(pTechno, kamikazePos);
+			// ① TechnoStatus 目标缓存（挂载时固化；NoUpdate=yes 只读格子，目标死活不影响）
+			TechnoStatus* cacheStatus = GetStatus<TechnoExt, TechnoStatus>(pTechno);
+			if (cacheStatus && cacheStatus->HasVectorTargetCache())
 			{
-				CoordStruct kamikazePos{};
-				bool gotKamikaze = TryGetKamikazeTarget(pTechno, kamikazePos);
-				// ① TechnoStatus 目标缓存（挂载时固化；NoUpdate=yes 只读格子，目标死活不影响）
-				TechnoStatus* cacheStatus = GetStatus<TechnoExt, TechnoStatus>(pTechno);
-				if (cacheStatus && cacheStatus->HasVectorTargetCache()
-					&& !IsSameCell(cacheStatus->GetVectorCachedCell(), pTechno->GetCoords()))
-				{
-					_initialOriginPos = cacheStatus->GetVectorCachedCell();
-				}
-				else if (gotKamikaze)
-				{
-					_initialOriginPos = kamikazePos;
-				}
-				else if (TryGetSpawnManagerTarget(pTechno, _initialOriginPos))
-				{
-					// 未进 Kamikaze 容器（导弹未全部发射）时读源头：SpawnManager 目标
-				}
-				else if (pTechno->Target && !IsSelfCellTarget(pTechno, pTechno->Target))
-				{
-					_initialOriginPos = pTechno->Target->GetCoords();
-				}
+				_initialOriginPos = cacheStatus->GetVectorCachedCell();
+			}
+			else if (gotKamikaze)
+			{
+				_initialOriginPos = kamikazePos;
+			}
+			else if (TryGetSpawnManagerTarget(pTechno, _initialOriginPos))
+			{
+				// 未进 Kamikaze 容器（导弹未全部发射）时读源头：SpawnManager 目标
+			}
+			else if (pTechno->Target)
+			{
+				_initialOriginPos = pTechno->Target->GetCoords();
+			}
 				else
 				{
 					// Kamikaze 容器此刻可能还没加入导弹（发射后才加入）：不锁自身，
@@ -625,7 +597,7 @@ VectorResult VectorEffect::GetVectorResult()
 	}
 
 	// 每帧运动刷新目标缓存：挂载时（OnStart）已写第一笔，这里跟随目标移动刷新；
-	// 目标死亡/无效（取不到/脚下格子）时停止写入，冻结最后有效值
+	// 目标死亡时停止写入，冻结最后有效值
 	CacheTargetNow();
 
 	// 目标坐标固化：OnStart 未锁定（Pending）时补读，读到即锁定到 _initialOriginPos，
@@ -637,8 +609,7 @@ VectorResult VectorEffect::GetVectorResult()
 		bool got = false;
 		if (TechnoStatus* status = GetStatus<TechnoExt, TechnoStatus>(pTechno))
 		{
-			if (status->HasVectorTargetCache()
-				&& !IsSameCell(status->GetVectorCachedCell(), pTechno->GetCoords()))
+			if (status->HasVectorTargetCache())
 			{
 				targetPos = status->GetVectorCachedCell();
 				got = true;
@@ -646,7 +617,7 @@ VectorResult VectorEffect::GetVectorResult()
 		}
 		if (!got && TryGetKamikazeTarget(pTechno, targetPos)) got = true;
 		if (!got && TryGetSpawnManagerTarget(pTechno, targetPos)) got = true;
-		if (!got && pTechno->Target && !IsSelfCellTarget(pTechno, pTechno->Target)) { targetPos = pTechno->Target->GetCoords(); got = true; }
+		if (!got && pTechno->Target) { targetPos = pTechno->Target->GetCoords(); got = true; }
 		if (got)
 		{
 			_initialOriginPos = targetPos;
@@ -865,8 +836,7 @@ VectorResult VectorEffect::GetVectorResult()
 			{
 				if (TechnoStatus* status = GetStatus<TechnoExt, TechnoStatus>(pTechno))
 				{
-					if (status->HasVectorTargetCache()
-						&& !IsSameCell(status->GetVectorCachedCell(), pTechno->GetCoords()))
+					if (status->HasVectorTargetCache())
 					{
 						targetPos = status->GetVectorCachedCell();
 						gotTarget = true;
@@ -883,7 +853,7 @@ VectorResult VectorEffect::GetVectorResult()
 				targetPos = pBullet->TargetCoords;
 				gotTarget = true;
 			}
-			else if (!gotTarget && pTechno && pTechno->Target && !IsSelfCellTarget(pTechno, pTechno->Target))
+			else if (!gotTarget && pTechno && pTechno->Target)
 			{
 				targetPos = pTechno->Target->GetCoords();
 				gotTarget = true;
@@ -891,8 +861,7 @@ VectorResult VectorEffect::GetVectorResult()
 			else if (!gotTarget && pTechno)
 			{
 				CoordStruct kamikazePos{};
-				if ((TryGetKamikazeTarget(pTechno, kamikazePos) || TryGetSpawnManagerTarget(pTechno, kamikazePos))
-					&& !IsSameCell(kamikazePos, pTechno->GetCoords())) // 脚下格子抛弃
+				if (TryGetKamikazeTarget(pTechno, kamikazePos) || TryGetSpawnManagerTarget(pTechno, kamikazePos))
 				{
 					targetPos = kamikazePos;
 					gotTarget = true;
@@ -963,15 +932,14 @@ VectorResult VectorEffect::GetVectorResult()
 		else
 		{
 			// 允许更新（NoUpdate=no）：缓存优先（只跟随锁定单位，防引擎集结目标点污染），
-			// 缓存空才回退引擎链；更新结果变成脚下格子（目标死亡）时抛弃，回退锁定坐标
+			// 缓存空才回退引擎链；目标死亡后缓存冻结，回退锁定坐标
 			CoordStruct updated{};
 			bool gotUpdate = false;
 			if (pTechno)
 			{
 				if (TechnoStatus* status = GetStatus<TechnoExt, TechnoStatus>(pTechno))
 				{
-					if (status->HasVectorTargetCache()
-						&& !IsSameCell(status->GetVectorCachedCell(), pTechno->GetCoords()))
+					if (status->HasVectorTargetCache())
 					{
 						updated = status->GetVectorCachedCell();
 						gotUpdate = true;
@@ -980,7 +948,7 @@ VectorResult VectorEffect::GetVectorResult()
 			}
 			if (!gotUpdate && pBullet && pBullet->Target)
 			{
-				updated = pBullet->Target->GetCoords(); // 抛射体目标 Cell 是真实落点，不判脚下
+				updated = pBullet->Target->GetCoords(); // 抛射体目标 Cell 是真实落点
 				gotUpdate = true;
 			}
 			else if (!gotUpdate && pBullet)
@@ -988,7 +956,7 @@ VectorResult VectorEffect::GetVectorResult()
 				updated = pBullet->TargetCoords;
 				gotUpdate = true;
 			}
-			else if (!gotUpdate && pTechno && pTechno->Target && !IsSelfCellTarget(pTechno, pTechno->Target))
+			else if (!gotUpdate && pTechno && pTechno->Target)
 			{
 				updated = pTechno->Target->GetCoords();
 				gotUpdate = true;
@@ -996,8 +964,7 @@ VectorResult VectorEffect::GetVectorResult()
 			else if (!gotUpdate && pTechno)
 			{
 				CoordStruct kamikazePos{};
-				if ((TryGetKamikazeTarget(pTechno, kamikazePos) || TryGetSpawnManagerTarget(pTechno, kamikazePos))
-					&& !IsSameCell(kamikazePos, pTechno->GetCoords())) // 脚下格子抛弃
+				if (TryGetKamikazeTarget(pTechno, kamikazePos) || TryGetSpawnManagerTarget(pTechno, kamikazePos))
 				{
 					updated = kamikazePos;
 					gotUpdate = true;
@@ -1805,6 +1772,18 @@ VectorResult VectorEffect::GetVectorResult()
 	dirVec.Z = frameTarget.Z - currentPos.Z;
 	double dirLen = std::sqrt(static_cast<double>(dirVec.X * dirVec.X + dirVec.Y * dirVec.Y + dirVec.Z * dirVec.Z));
 
+	// 同步 Rocket loco 俯仰角：引擎自主移动姿态与 Vector 移动向量一致，
+	// 防止 Vector 结束后引擎按错误的 Pitch 继续飞行导致命中偏移（Spawn 导弹用 RocketLocomotionClass）
+	if (pTechno)
+	{
+		if (RocketLocomotionClass* rLoco = dynamic_cast<RocketLocomotionClass*>(
+			abstract_cast<FootClass*, true>(pTechno)->Locomotor.get()))
+		{
+			double lenXY = std::sqrt(static_cast<double>(dirVec.X * dirVec.X + dirVec.Y * dirVec.Y));
+			rLoco->CurrentPitch = static_cast<float>(std::atan2(dirVec.Z, lenXY));
+		}
+	}
+
 	CoordStruct resultDisp{ 0, 0, 0 };
 
 	// ========================================================================
@@ -1952,6 +1931,7 @@ VectorResult VectorEffect::GetVectorResult()
 			double realDist = std::sqrt(realDX * realDX + realDY * realDY + realDZ * realDZ);
 			if (realDist <= speed)
 			{
+				// 强制挪移：到达帧直接把对象坐标设为目标格子坐标（完全重合），消除到位抖动
 				if (pBullet)
 				{
 					pBullet->SetLocation(frameTarget);
@@ -1961,11 +1941,14 @@ VectorResult VectorEffect::GetVectorResult()
 				}
 				else if (pTechno)
 				{
-					// 单位侧：位移 = 剩余距离，一步到位（Vector.cpp 会 SetLocation 到 frameTarget）
-					result.MoveDisp.X = frameTarget.X - currentPos.X;
-					result.MoveDisp.Y = frameTarget.Y - currentPos.Y;
-					result.MoveDisp.Z = frameTarget.Z - currentPos.Z;
-					result.Force = true;
+					// 强制挪移：直接 SetLocation 到目标格子坐标（含占位更新），不再经 MoveDisp 管线
+					bool onBridge = pTechno->OnBridge;
+					pTechno->UpdatePlacement(PlacementType::Remove);
+					pTechno->OnBridge = onBridge;
+					pTechno->SetLocation(frameTarget);
+					pTechno->UpdatePlacement(PlacementType::Put);
+					result.MoveDisp = { 0, 0, 0 };
+					result.Force = false;
 				}
 				Deactivate();
 				AdvanceFrame();

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -29,7 +29,7 @@ void VectorEffect::OnStart()
 	_currentAngle = 0.0;
 	// _prevCirclePos = pObject->GetCoords();  // [DEAD] 从未读取
 	_effectiveTimeStep = Data->TimeStep;
-	_prevCircleCenter = pObject->GetCoords();
+	// _prevCircleCenter 不在此初始化：圆心追踪依赖 Origin 移动系统首帧的 skipOriginUpdate 赋值
 
 	_initialLocation = pObject->GetCoords();
 	_vectorAcquireZ = _initialLocation.Z;  // Circle 圆心高度基准：获取 Vector 时的 Z
@@ -663,7 +663,7 @@ VectorResult VectorEffect::GetVectorResult()
 
 		// 圆心移动：Vector.Origin.* 系统
 		if (!Data->OriginMoveTo.IsEmpty() || !Data->OriginTargetFLH.IsEmpty()
-			|| Data->OriginCircleRadius >= 0 || Data->OriginCircleSpeed != 0 || Data->OriginLinearSpeed >= 0 || Data->OriginCircleAnglePerStep != 0)
+			|| Data->OriginCircleRadius >= 0 || Data->OriginCircleSpeed != 0 || Data->OriginCircleAnglePerStep != 0)
 		{
 			// 基座：默认 originPos，OriginOrigin 可替换为独立参考系
 			CoordStruct baseCenter = originPos;
@@ -714,8 +714,14 @@ VectorResult VectorEffect::GetVectorResult()
 				_originOffset = circleCenter - baseCenter;
 				// Circle 初始化
 				_originCircleRadius = Data->OriginCircleRadius;
-				_originCircleSpeed = Data->OriginLinearSpeed >= 0 ? Data->OriginLinearSpeed : Data->OriginCircleSpeed;
+				_originCircleSpeed = Data->OriginCircleSpeed;
 				_originCircleAngle = 0.0; // 初始相位
+				// 未显式设半径：取当前偏移的水平距离
+				if (_originCircleRadius < 0)
+					_originCircleRadius = (int)std::sqrt(
+						(double)_originOffset.X * _originOffset.X +
+						(double)_originOffset.Y * _originOffset.Y +
+						(double)_originOffset.Z * _originOffset.Z);
 				// 随机
 				if (Data->OriginCircleRandomRadiusMax > Data->OriginCircleRandomRadiusMin)
 					_originCircleRadius = Random::RandomRanged(Data->OriginCircleRandomRadiusMin, Data->OriginCircleRandomRadiusMax);
@@ -741,10 +747,13 @@ VectorResult VectorEffect::GetVectorResult()
 				_originNormalStepF = res(Data->OriginNormalFAnglePerStep, Data->OriginNormalFAngleRMin, Data->OriginNormalFAngleRMax, Data->OriginNormalFAngleRMin2, Data->OriginNormalFAngleRMax2);
 				_originNormalStepL = res(Data->OriginNormalLAnglePerStep, Data->OriginNormalLAngleRMin, Data->OriginNormalLAngleRMax, Data->OriginNormalLAngleRMin2, Data->OriginNormalLAngleRMax2);
 				_originNormalStepH = res(Data->OriginNormalHAnglePerStep, Data->OriginNormalHAngleRMin, Data->OriginNormalHAngleRMax, Data->OriginNormalHAngleRMin2, Data->OriginNormalHAngleRMax2);
-				if (!Data->OriginNormalVector.IsEmpty() && !_originCircleRadius)
-					_originCircleRadius = -1;  // 有 NormalVector 但无显式半径，自动取当前距离
-				// 无 NormalVector 时从 Origin 参考系取 facing
+			// 无 NormalVector 时：默认水平圆面（法向量朝上）
 				if (Data->OriginNormalVector.IsEmpty())
+				{
+					_originFacing = 0;
+					_originTilt = M_PI / 2.0;
+				}
+				else
 				{
 					switch (Data->OriginOrigin)
 					{
@@ -864,8 +873,8 @@ VectorResult VectorEffect::GetVectorResult()
 				if (Data->OriginCircleMinRadius > 0 && tr < Data->OriginCircleMinRadius) tr = Data->OriginCircleMinRadius;
 				// 角步长：优先线速度/半径推算，否则用固定角速度
 				double originAngleStep = Data->OriginCircleAnglePerStep;
-				if (_originCircleSpeed != 0 && tr > 0)
-					originAngleStep = Math::rad2deg(_originCircleSpeed / tr);
+				if (Data->OriginCircleSpeed != 0 && tr > 0)
+					originAngleStep = Math::rad2deg(Data->OriginCircleSpeed / tr);
 				// Lissajous=yes: 累积大角旋转（增减边震荡），no: 每帧仅增量旋转（平滑行星）
 				_originCircleAngle += originAngleStep;
 				double r = Data->OriginLissajous ? Math::deg2rad(_originCircleAngle) : Math::deg2rad(originAngleStep);

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -1070,7 +1070,21 @@ VectorResult VectorEffect::GetVectorResult()
 		if (Data->MaxSpeed >= 0 && speed > Data->MaxSpeed)
 			speed = static_cast<double>(Data->MaxSpeed);
 
-		// 无弧线：影子仅追踪 XY，Z 独立插值避免增量累积
+		// SpeedEndOnReach=no：不走影子系统，全程旧版 dirVec/dirLen 直追（自然产生抽搐跟随）
+		if (!Data->SpeedEndOnReach)
+		{
+			if (dirLen > 1e-6)
+			{
+				resultDisp.X = static_cast<int>(dirVec.X / dirLen * speed);
+				resultDisp.Y = static_cast<int>(dirVec.Y / dirLen * speed);
+				resultDisp.Z = static_cast<int>(dirVec.Z / dirLen * speed);
+			}
+			result.MoveDisp = resultDisp;
+			AdvanceFrame();
+			return result;
+		}
+
+		// 以下：SpeedEndOnReach=yes，走影子系统
 		// 有弧线：影子追踪完整 3D，弧高增量叠加
 		double sdx = frameTarget.X - _shadowPosX;
 		double sdy = frameTarget.Y - _shadowPosY;
@@ -1199,19 +1213,6 @@ VectorResult VectorEffect::GetVectorResult()
 					}
 				}
 			}
-		}
-		else if (!Data->SpeedEndOnReach)
-		{
-			// 影子已到达目标，但 SpeedEndOnReach=no：
-			// 用实时方向继续追踪，保留旧版追着目标抖动的行为
-			// 弧高已在 t=1.0 归零，不再叠加
-			if (dirLen > 1e-6)
-			{
-				resultDisp.X = static_cast<int>(dirVec.X / dirLen * speed);
-				resultDisp.Y = static_cast<int>(dirVec.Y / dirLen * speed);
-				resultDisp.Z = static_cast<int>(dirVec.Z / dirLen * speed);
-			}
-			_prevArcOffset = 0.0;
 		}
 		result.MoveDisp = resultDisp;
 		AdvanceFrame();

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -2,6 +2,9 @@
 
 #include <Utilities/Debug.h>
 
+#include <Kamikaze.h>
+#include <SpawnManagerClass.h>
+
 #include <Ext/Helper/Scripts.h>
 #include <Ext/Helper/Status.h>
 #include <Ext/Helper/Physics.h>
@@ -10,13 +13,158 @@
 
 #include <Ext/ObjectType/AttachEffect.h>
 #include <Ext/EffectType/AttachEffectScript.h>
+#include <Ext/TechnoType/TechnoStatus.h>
+#include <Extension/TechnoExt.h>
 
-std::map<TechnoClass*, CoordStruct> VectorEffect::_lastTargetCache;
 #include <Ext/BulletType/BulletStatus.h>
 
 
 // Vector: Freeze / Circle / MoveTo / Speed / ReachTarget
 // 基于 V1 VectorEffect.cpp 精简
+
+// ========================================================================
+// 目标有效性辅助（SpawnMissile 场景专用）
+// ========================================================================
+
+// 两点是否同一格子（256 lepton = 1 格，坐标 >>8 得格子号，仅 XY）
+static bool IsSameCell(CoordStruct a, CoordStruct b)
+{
+	return (a.X >> 8) == (b.X >> 8)
+		&& (a.Y >> 8) == (b.Y >> 8);
+}
+
+// 脚下格子通用过滤（默认全跳）：任何目标坐标与自身同格都视为无效。
+// 引擎两种场景会把导弹目标设成自身脚下格子——spawn 未全部出生前的占位目标、
+// 目标死亡后的重置（MissileHoming）。两种都不该被 Vector 采用，一律跳过。
+static bool IsSelfCellTarget(TechnoClass* pTechno, AbstractClass* pTarget)
+{
+	if (!pTarget)
+		return true;
+	return IsSameCell(pTarget->GetCoords(), pTechno->GetCoords());
+}
+
+// 从引擎 Kamikaze 控制器读导弹的目标点（现有基建，不自己造轮子）：
+// KamikazeControl->Cell 存目标格子——Homing 开启时每帧更新（目标活着跟随、死亡冻结），
+// 不 Homing 时由引擎写入目标 Cell。这是引擎眼中导弹真正要飞向的位置
+static bool TryGetKamikazeTarget(TechnoClass* pTechno, CoordStruct& out)
+{
+	AircraftClass* pAircraft = pTechno ? abstract_cast<AircraftClass*>(pTechno) : nullptr;
+	if (!pAircraft)
+		return false;
+	auto& nodes = Kamikaze::Instance->Nodes;
+	for (int i = 0; i < nodes.Count; i++)
+	{
+		Kamikaze::KamikazeControl* pControl = nodes[i];
+		if (pControl && pControl->Item == pAircraft && pControl->Cell)
+		{
+			out = pControl->Cell->GetCoords();
+			return true;
+		}
+	}
+	return false;
+}
+
+// 从 spawn 发射者的管理器读目标（Kamikaze Cell 的源头）：
+// KamikazeTrackerClass_Add 就是用 SpawnManager->Destination 设置 Cell 的。
+// 导弹未全部发射（未进 Kamikaze 容器）期间容器为空，直接读源头补全这一阶段
+static bool TryGetSpawnManagerTarget(TechnoClass* pTechno, CoordStruct& out)
+{
+	if (pTechno && pTechno->SpawnOwner && !IsDeadOrInvisible(pTechno->SpawnOwner))
+	{
+		SpawnManagerClass* pSM = pTechno->SpawnOwner->SpawnManager;
+		if (pSM)
+		{
+			if (pSM->Target)
+			{
+				out = pSM->Target->GetCoords();
+				return true;
+			}
+			if (pSM->Destination)
+			{
+				out = pSM->Destination->GetCoords();
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+// 目标缓存（挂在 TechnoStatus，归一目标保护机制）：
+// Techno 获得 Vector 时写入目标单位+格子（Spawn 从 SpawnManager/Kamikaze 取，普通单位记 Target）。
+// NoUpdate=yes 存一次即停，之后只读格子（目标死活不影响）；no 每帧刷新，目标死亡/无效（脚下格子）冻结最后有效值
+void VectorEffect::CacheTargetNow()
+{
+	if (!pTechno)
+		return;
+	TechnoStatus* status = GetStatus<TechnoExt, TechnoStatus>(pTechno);
+	if (!status)
+		return;
+
+	// NoUpdate=yes：第一笔（挂载时）已写入即停止刷新
+	if (Data->OriginNoUpdate && status->HasVectorTargetCache())
+		return;
+
+	AbstractClass* candTarget = nullptr;
+	CoordStruct candCell{};
+	bool got = false;
+
+	if (pTechno->SpawnOwner && !IsDeadOrInvisible(pTechno->SpawnOwner))
+	{
+		// Spawn 导弹：SpawnManager（单位+坐标）→ Kamikaze Cell（只有格子）→ Target（单位+坐标）
+		SpawnManagerClass* pSM = pTechno->SpawnOwner->SpawnManager;
+		if (pSM && pSM->Target)
+		{
+			TechnoClass* pTgt = abstract_cast<TechnoClass*>(pSM->Target);
+			CoordStruct c = pSM->Target->GetCoords();
+			if (!IsSameCell(c, pTechno->GetCoords())
+				&& (!pTgt || !IsDeadOrInvisible(pTgt))) // 非 Techno 目标（格子）不做死亡判断
+			{
+				candTarget = pSM->Target;
+				candCell = c;
+				got = true;
+			}
+		}
+		if (!got && pSM && pSM->Destination)
+		{
+			CoordStruct c = pSM->Destination->GetCoords();
+			if (!IsSameCell(c, pTechno->GetCoords()))
+			{
+				candCell = c;
+				got = true;
+			}
+		}
+		if (!got)
+		{
+			CoordStruct kamikazePos{};
+			if (TryGetKamikazeTarget(pTechno, kamikazePos) && !IsSameCell(kamikazePos, pTechno->GetCoords()))
+			{
+				candCell = kamikazePos;
+				got = true;
+			}
+		}
+		if (!got && pTechno->Target && !IsSelfCellTarget(pTechno, pTechno->Target))
+		{
+			candTarget = pTechno->Target;
+			candCell = pTechno->Target->GetCoords();
+			got = true;
+		}
+	}
+	else if (pTechno->Target && !IsSelfCellTarget(pTechno, pTechno->Target))
+	{
+		// 普通单位：直接记 Target
+		TechnoClass* pTgt = abstract_cast<TechnoClass*>(pTechno->Target);
+		if (!pTgt || !IsDeadOrInvisible(pTgt))
+		{
+			candTarget = pTechno->Target;
+			candCell = pTechno->Target->GetCoords();
+			got = true;
+		}
+	}
+
+	// 有效才写；无效（取不到/脚下格子/目标死亡）不写，保留最后有效值（冻结）
+	if (got)
+		status->SetVectorTargetCache(candTarget, candCell);
+}
 
 void VectorEffect::OnStart()
 {
@@ -204,41 +352,56 @@ void VectorEffect::OnStart()
 		_pLauncher = (AE && AE->pSource) ? AE->pSource : pTechno; // 单位侧用攻击者作为Launcher
 	}
 
+	// 挂载即初始化目标缓存（无论本段 Origin 是不是 Target，都记录）
+	// 保证后续 Target 段（可能目标已死）有坐标可读；NoUpdate=yes 时这里就是"存一次即停"的第一笔
+	CacheTargetNow();
+
 	// --- Origin 初始化 ---
 	switch (Data->Origin)
 	{
 	case VectorData::VectorOrigin::Target:
 		if (Data->OriginNoUpdate)
 		{
-			// 锚点 = 原定目标：攻击目标 → 移动目标(Destination) → 焦点(Focus) → 缓存 → 自身
-			if (pTechno && pTechno->Target)
-				_initialOriginPos = pTechno->Target->GetCoords();
-			else if (pTechno)
+			// 锚点 = 引擎 Kamikaze 控制器存的目标点（Homing 更新/引擎写入，目标死亡冻结）→ 攻击目标 → 自身
+			// 脚下格子（引擎占位/重置污染）默认全跳
+			if (pTechno)
 			{
-				FootClass* pFoot = abstract_cast<FootClass*>(pTechno);
-				if (pFoot && pFoot->Destination)
+				CoordStruct kamikazePos{};
+				bool gotKamikaze = TryGetKamikazeTarget(pTechno, kamikazePos);
+				// ① TechnoStatus 目标缓存（挂载时固化；NoUpdate=yes 只读格子，目标死活不影响）
+				TechnoStatus* cacheStatus = GetStatus<TechnoExt, TechnoStatus>(pTechno);
+				if (cacheStatus && cacheStatus->HasVectorTargetCache()
+					&& !IsSameCell(cacheStatus->GetVectorCachedCell(), pTechno->GetCoords()))
 				{
-					_initialOriginPos = pFoot->Destination->GetCoords();
-					_lastTargetCache[pTechno] = _initialOriginPos;
+					_initialOriginPos = cacheStatus->GetVectorCachedCell();
 				}
-				else if (pTechno->Focus)
+				else if (gotKamikaze)
 				{
-					_initialOriginPos = pTechno->Focus->GetCoords();
-					_lastTargetCache[pTechno] = _initialOriginPos;
+					_initialOriginPos = kamikazePos;
+				}
+				else if (TryGetSpawnManagerTarget(pTechno, _initialOriginPos))
+				{
+					// 未进 Kamikaze 容器（导弹未全部发射）时读源头：SpawnManager 目标
+				}
+				else if (pTechno->Target && !IsSelfCellTarget(pTechno, pTechno->Target))
+				{
+					_initialOriginPos = pTechno->Target->GetCoords();
 				}
 				else
 				{
-					auto it = _lastTargetCache.find(pTechno);
-					if (it != _lastTargetCache.end())
-						_initialOriginPos = it->second;
-					else
-						_initialOriginPos = pObject->GetCoords();
+					// Kamikaze 容器此刻可能还没加入导弹（发射后才加入）：不锁自身，
+					// 留空由 GetVectorResult 首帧补读
+					_initialOriginPos = CoordStruct::Empty;
 				}
 			}
 			else if (pBullet)
+			{
 				_initialOriginPos = pBullet->TargetCoords;
+			}
 			else
+			{
 				_initialOriginPos = pObject->GetCoords();
+			}
 		}
 		break;
 
@@ -414,10 +577,6 @@ VectorResult VectorEffect::GetVectorResult()
 {
 	VectorResult result;
 
-	if (Data->ReachTarget)
-		Debug::Log("[VectorG] enter el=%d moveF=%d mf=%d total=%d ts=%d started=%d\n",
-			_elapsedFrames, _moveFrame, _movementFrames, _totalDuration, _effectiveTimeStep, (int)_started);
-
 	// 首帧快照（仅一次，供弧高计算等）
 	if (_elapsedFrames == 0)
 		_initialLocation = pObject->GetCoords();
@@ -427,6 +586,35 @@ VectorResult VectorEffect::GetVectorResult()
 	{
 		AdvanceFrame();
 		return result;
+	}
+
+	// 每帧运动刷新目标缓存：挂载时（OnStart）已写第一笔，这里跟随目标移动刷新；
+	// 目标死亡/无效（取不到/脚下格子）时停止写入，冻结最后有效值
+	CacheTargetNow();
+
+	// 目标坐标固化：OnStart 未锁定（Pending）时补读，读到即锁定到 _initialOriginPos，
+	// 防止引擎后续清空（目标死亡/管理器清空）导致 frameTarget 失效
+	if (Data->Origin == VectorData::VectorOrigin::Target
+		&& _initialOriginPos.IsEmpty() && pTechno)
+	{
+		CoordStruct targetPos{};
+		bool got = false;
+		if (TechnoStatus* status = GetStatus<TechnoExt, TechnoStatus>(pTechno))
+		{
+			if (status->HasVectorTargetCache()
+				&& !IsSameCell(status->GetVectorCachedCell(), pTechno->GetCoords()))
+			{
+				targetPos = status->GetVectorCachedCell();
+				got = true;
+			}
+		}
+		if (!got && TryGetKamikazeTarget(pTechno, targetPos)) got = true;
+		if (!got && TryGetSpawnManagerTarget(pTechno, targetPos)) got = true;
+		if (!got && pTechno->Target && !IsSelfCellTarget(pTechno, pTechno->Target)) { targetPos = pTechno->Target->GetCoords(); got = true; }
+		if (got)
+		{
+			_initialOriginPos = targetPos;
+		}
 	}
 
 	// Force 必须在闸门之前设，确保非运动帧也走 SetLocation（Freeze 等效）
@@ -493,22 +681,6 @@ VectorResult VectorEffect::GetVectorResult()
 		return result;
 	}
 	_movementFrames++;
-
-	// 每帧更新缓存：即使 OnStart 时 Target 为空，后续帧获取后也能传递
-	if (pTechno)
-	{
-		CoordStruct cached;
-		bool got = false;
-		if (pTechno->Target) { cached = pTechno->Target->GetCoords(); got = true; }
-		else
-		{
-			FootClass* pf = abstract_cast<FootClass*>(pTechno);
-			if (pf && pf->Destination) { cached = pf->Destination->GetCoords(); got = true; }
-			else if (pTechno->Focus) { cached = pTechno->Focus->GetCoords(); got = true; }
-		}
-		if (got)
-			_lastTargetCache[pTechno] = cached;
-	}
 
 	_normalRotF += _lissajousStep;
 	// 3D 法向量增量旋转（绕世界 F=Y / L=X / H=Z 轴，正速度=顺时针）
@@ -650,60 +822,50 @@ VectorResult VectorEffect::GetVectorResult()
 			bool isGround = (pBullet && !abstract_cast<TechnoClass*>(pBullet->Target));
 			if (isGround && _movementFrames > 1)
 				break;
-			CoordStruct targetPos;
-			if (pBullet && pBullet->Target)
+			// 允许更新（NoUpdate=no）：缓存优先（每帧已刷新，目标死亡冻结），缓存空回退引擎来源
+			CoordStruct targetPos = _initialOriginPos;
+			bool gotTarget = !targetPos.IsEmpty();
+			if (pTechno)
 			{
-				// 地面目标（Cell，非 ObjectClass）永远有效；单位目标死亡才冻结
-				ObjectClass* pTgtObj = abstract_cast<ObjectClass*>(pBullet->Target);
-				if (!pTgtObj || !IsDeadOrInvisible(pTgtObj))
+				if (TechnoStatus* status = GetStatus<TechnoExt, TechnoStatus>(pTechno))
 				{
-					_initialOriginPos = pBullet->Target->GetCoords(); // 目标有效：更新快照
-					targetPos = _initialOriginPos;
-				}
-				else
-					targetPos = _initialOriginPos.IsEmpty() ? pBullet->TargetCoords : _initialOriginPos; // 单位目标死亡：冻结
-			}
-			else if (pBullet)
-				targetPos = _initialOriginPos.IsEmpty() ? pBullet->TargetCoords : _initialOriginPos; // 无 Target：地面落点/冻结快照
-			else if (pTechno && pTechno->Target)
-			{
-				// 地面目标（Cell，非 ObjectClass）永远有效；单位目标死亡才冻结
-				ObjectClass* pTgtObj = abstract_cast<ObjectClass*>(pTechno->Target);
-				if (!pTgtObj || !IsDeadOrInvisible(pTgtObj))
-				{
-					_initialOriginPos = pTechno->Target->GetCoords(); // 目标有效：更新快照
-					targetPos = _initialOriginPos;
-				}
-				else
-					targetPos = _initialOriginPos.IsEmpty() ? currentPos : _initialOriginPos; // 单位目标死亡：冻结
-			}
-			else if (pTechno)
-			{
-				if (!_initialOriginPos.IsEmpty())
-				{
-					// 目标死亡：冻结死亡坐标，朝向保持指向死亡点
-					targetPos = _initialOriginPos;
-				}
-				else
-				{
-					// 从未有过目标：回退移动目标(Destination) → 焦点(Focus) → 缓存，都没有则什么都不做（保持朝向）
-					FootClass* pFoot = abstract_cast<FootClass*>(pTechno);
-					if (pFoot && pFoot->Destination)
-						targetPos = pFoot->Destination->GetCoords();
-					else if (pTechno->Focus)
-						targetPos = pTechno->Focus->GetCoords();
-					else
+					if (status->HasVectorTargetCache()
+						&& !IsSameCell(status->GetVectorCachedCell(), pTechno->GetCoords()))
 					{
-						auto it = _lastTargetCache.find(pTechno);
-						if (it != _lastTargetCache.end())
-							targetPos = it->second;
-						else
-							break;
+						targetPos = status->GetVectorCachedCell();
+						gotTarget = true;
 					}
 				}
 			}
-			else
-				break;
+			if (!gotTarget && pBullet && pBullet->Target)
+			{
+				targetPos = pBullet->Target->GetCoords(); // 抛射体目标 Cell 是真实落点
+				gotTarget = true;
+			}
+			else if (!gotTarget && pBullet)
+			{
+				targetPos = pBullet->TargetCoords;
+				gotTarget = true;
+			}
+			else if (!gotTarget && pTechno && pTechno->Target && !IsSelfCellTarget(pTechno, pTechno->Target))
+			{
+				targetPos = pTechno->Target->GetCoords();
+				gotTarget = true;
+			}
+			else if (!gotTarget && pTechno)
+			{
+				CoordStruct kamikazePos{};
+				if ((TryGetKamikazeTarget(pTechno, kamikazePos) || TryGetSpawnManagerTarget(pTechno, kamikazePos))
+					&& !IsSameCell(kamikazePos, pTechno->GetCoords())) // 脚下格子抛弃
+				{
+					targetPos = kamikazePos;
+					gotTarget = true;
+				}
+			}
+			if (gotTarget)
+				_initialOriginPos = targetPos; // 跟随：更新锁定值
+			else if (targetPos.IsEmpty())
+				break; // 从未有过目标：保持朝向
 			mainFacingDir = Point2Dir(targetPos, currentPos); // 官方API，不得修改
 			effectiveFacing = mainFacingDir.GetRadian();
 			double dx = currentPos.X - targetPos.X, dy = currentPos.Y - targetPos.Y, dz = currentPos.Z - targetPos.Z;
@@ -761,46 +923,45 @@ VectorResult VectorEffect::GetVectorResult()
 	{
 	case VectorData::VectorOrigin::Target:
 		if (Data->OriginNoUpdate)
-			originPos = _initialOriginPos;
-		else if (pBullet && pBullet->Target)
-		{
-			// 地面目标（Cell，非 ObjectClass）永远有效；单位目标死亡才冻结
-			ObjectClass* pTgtObj = abstract_cast<ObjectClass*>(pBullet->Target);
-			if (!pTgtObj || !IsDeadOrInvisible(pTgtObj))
-			{
-				_initialOriginPos = pBullet->Target->GetCoords(); // 目标有效：每帧更新快照
-				originPos = _initialOriginPos;
-			}
-			else
-				originPos = _initialOriginPos.IsEmpty() ? pBullet->TargetCoords : _initialOriginPos; // 单位目标死亡：冻结
-		}
-		else if (pBullet)
-			originPos = _initialOriginPos.IsEmpty() ? pBullet->TargetCoords : _initialOriginPos; // 无 Target：地面落点/冻结快照
-		else if (pTechno && pTechno->Target)
-		{
-			// 地面目标（Cell，非 ObjectClass）永远有效；单位目标死亡才冻结
-			ObjectClass* pTgtObj = abstract_cast<ObjectClass*>(pTechno->Target);
-			if (!pTgtObj || !IsDeadOrInvisible(pTgtObj))
-			{
-				_initialOriginPos = pTechno->Target->GetCoords(); // 目标有效：每帧更新快照
-				originPos = _initialOriginPos;
-			}
-			else
-				originPos = _initialOriginPos.IsEmpty() ? currentPos : _initialOriginPos; // 单位目标死亡：冻结死亡坐标
-		}
+			originPos = _initialOriginPos.IsEmpty() ? currentPos : _initialOriginPos; // 锁定初始目标
 		else
 		{
-			// 无 Target：实例快照 → 全局缓存 → 自身
-			if (!_initialOriginPos.IsEmpty())
-				originPos = _initialOriginPos;
-			else
+			// 允许更新：每帧从引擎读目标跟随移动（NoUpdate=no 语义）；
+			// 更新结果变成导弹自身格子（目标死亡，引擎重置）时抛弃该帧，回退到已锁定坐标
+			CoordStruct updated{};
+			bool gotUpdate = false;
+			if (pBullet && pBullet->Target)
 			{
-				auto it = _lastTargetCache.find(pTechno);
-				if (it != _lastTargetCache.end())
-					originPos = it->second;
-				else
-					originPos = currentPos;
+				updated = pBullet->Target->GetCoords(); // 抛射体目标 Cell 是真实落点，不判脚下
+				gotUpdate = true;
 			}
+			else if (pBullet)
+			{
+				updated = pBullet->TargetCoords;
+				gotUpdate = true;
+			}
+			else if (pTechno && pTechno->Target && !IsSelfCellTarget(pTechno, pTechno->Target))
+			{
+				updated = pTechno->Target->GetCoords();
+				gotUpdate = true;
+			}
+			else if (pTechno)
+			{
+				CoordStruct kamikazePos{};
+				if ((TryGetKamikazeTarget(pTechno, kamikazePos) || TryGetSpawnManagerTarget(pTechno, kamikazePos))
+					&& !IsSameCell(kamikazePos, pTechno->GetCoords())) // 脚下格子抛弃
+				{
+					updated = kamikazePos;
+					gotUpdate = true;
+				}
+			}
+			if (gotUpdate)
+			{
+				_initialOriginPos = updated; // 跟随：更新锁定值
+				originPos = _initialOriginPos;
+			}
+			else
+				originPos = _initialOriginPos.IsEmpty() ? currentPos : _initialOriginPos; // 抛弃 update → 回退锁定坐标
 		}
 		break;
 	case VectorData::VectorOrigin::Launcher:
@@ -1606,24 +1767,9 @@ VectorResult VectorEffect::GetVectorResult()
 			int effectiveDuration = _totalDuration - Data->DisabledFrames;
 		if (effectiveDuration < 1) effectiveDuration = 1;
 		int remainingFrames = effectiveDuration - _movementFrames + 1;
-		AbstractClass* pRealTarget = pBullet ? pBullet->Target : (pTechno ? pTechno->Target : nullptr);
-		ObjectClass* pRealTargetObj = pRealTarget ? abstract_cast<ObjectClass*>(pRealTarget) : nullptr;
-		Debug::Log("[VectorReach] mf=%d rem=%d eff=%d cur=(%d,%d,%d) frameTarget=(%d,%d,%d)\n"
-			"  originPos=(%d,%d,%d) realTarget=%p what=%d alive=%d tgtPos=(%d,%d,%d)\n",
-			_movementFrames, remainingFrames, effectiveDuration,
-			currentPos.X, currentPos.Y, currentPos.Z,
-			frameTarget.X, frameTarget.Y, frameTarget.Z,
-			originPos.X, originPos.Y, originPos.Z,
-			(void*)pRealTarget,
-			pRealTarget ? (int)pRealTarget->WhatAmI() : -1,
-			pRealTargetObj ? (int)IsDeadOrInvisible(pRealTargetObj) : -1,
-			pRealTarget ? pRealTarget->GetCoords().X : 0,
-			pRealTarget ? pRealTarget->GetCoords().Y : 0,
-			pRealTarget ? pRealTarget->GetCoords().Z : 0);
 		if (Data->ReachTargetEarlyEnd > 0 && Data->ReachTargetEarlyEnd < effectiveDuration
 			&& remainingFrames <= Data->ReachTargetEarlyEnd)
 		{
-			Debug::Log("[VectorReach] EARLYEND rem=%d\n", remainingFrames);
 			Deactivate();
 			AdvanceFrame();
 			return result;
@@ -1637,31 +1783,42 @@ VectorResult VectorEffect::GetVectorResult()
 			resultDisp.Y = static_cast<int>(dirVec.Y / dirLen * adjustedSpeed);
 			resultDisp.Z = static_cast<int>(dirVec.Z / dirLen * adjustedSpeed);
 
-			// 抛物线弧高（基于弧线起点，支持 ArcPeakPercent / ArcRotation）
+			// 抛物线弧高（Speed 模式影子算法：增量叠加，t 跟随实际路程，目标移动自动校准）
 			if (_arcHeight != 0)
 			{
-				if (_arcStartLocation.IsEmpty())
-					_arcStartLocation = currentPos; // 首次弧线执行时抓取当前位置作为起点
-				// AE 根基缺陷（实际运动帧 = 总帧数-1）：t 按 mf 1..eff-1 映射 0..1，末帧到位
-				double t = (effectiveDuration > 2)
-					? static_cast<double>(_movementFrames - 1) / (effectiveDuration - 2)
-					: 1.0;
+				// 影子沿 frameTarget 方向推进 adjustedSpeed（与直线均分同步）
+				double ux = dirVec.X / dirLen, uy = dirVec.Y / dirLen, uz = dirVec.Z / dirLen;
+				_shadowPosX += ux * adjustedSpeed;
+				_shadowPosY += uy * adjustedSpeed;
+				_shadowPosZ += uz * adjustedSpeed;
+				_shadowTraveled += adjustedSpeed;
+
+				// 剩余影子距离（3D）
+				double sdx = frameTarget.X - _shadowPosX;
+				double sdy = frameTarget.Y - _shadowPosY;
+				double sdz = frameTarget.Z - _shadowPosZ;
+				double shadowDist = std::sqrt(sdx * sdx + sdy * sdy + sdz * sdz);
+
+				// t = 已走路程 / 总路程（动态更新，目标移动时自动调整）
+				double total = _shadowTraveled + shadowDist;
+				double t = (total > 1e-6) ? _shadowTraveled / total : 0.0;
+				if (t < 0.0) t = 0.0; else if (t > 1.0) t = 1.0;
+
+				// 弧高增量叠加（不覆盖直线位移）
 				double arcOffset = CalcArcOffsetAt(t);
-				double baseX = _arcStartLocation.X + (frameTarget.X - _arcStartLocation.X) * t;
-				double baseY = _arcStartLocation.Y + (frameTarget.Y - _arcStartLocation.Y) * t;
-				double baseZ = _arcStartLocation.Z + (frameTarget.Z - _arcStartLocation.Z) * t;
+				double arcDelta = arcOffset - _prevArcOffset;
+				_prevArcOffset = arcOffset;
 
 				if (_arcRotation == 0.0)
 				{
-					resultDisp.X = static_cast<int>(baseX - currentPos.X);
-					resultDisp.Y = static_cast<int>(baseY - currentPos.Y);
-					resultDisp.Z = static_cast<int>(baseZ + arcOffset - currentPos.Z);
+					resultDisp.Z += static_cast<int>(arcDelta);
 				}
 				else
 				{
-					double dx = frameTarget.X - _arcStartLocation.X;
-					double dy = frameTarget.Y - _arcStartLocation.Y;
-					double dz = frameTarget.Z - _arcStartLocation.Z;
+					// 旋转弧面：弧高分解到 XYZ（与 Speed 模式一致，D = frameTarget - _initialLocation）
+					double dx = frameTarget.X - _initialLocation.X;
+					double dy = frameTarget.Y - _initialLocation.Y;
+					double dz = frameTarget.Z - _initialLocation.Z;
 					double dLen = std::sqrt(dx * dx + dy * dy + dz * dz);
 					if (dLen > 1e-6)
 					{
@@ -1680,15 +1837,13 @@ VectorResult VectorEffect::GetVectorResult()
 						double rx = pnx * c + (dny * pnz - dnz * pny) * s;
 						double ry = pny * c + (dnz * pnx - dnx * pnz) * s;
 						double rz = pnz * c + (dnx * pny - dny * pnx) * s;
-						resultDisp.X = static_cast<int>(baseX + rx * arcOffset - currentPos.X);
-						resultDisp.Y = static_cast<int>(baseY + ry * arcOffset - currentPos.Y);
-						resultDisp.Z = static_cast<int>(baseZ + rz * arcOffset - currentPos.Z);
+						resultDisp.X += static_cast<int>(rx * arcDelta);
+						resultDisp.Y += static_cast<int>(ry * arcDelta);
+						resultDisp.Z += static_cast<int>(rz * arcDelta);
 					}
 					else
 					{
-						resultDisp.X = static_cast<int>(baseX - currentPos.X);
-						resultDisp.Y = static_cast<int>(baseY - currentPos.Y);
-						resultDisp.Z = static_cast<int>(baseZ + arcOffset - currentPos.Z);
+						resultDisp.Z += static_cast<int>(arcDelta);
 					}
 				}
 			}
@@ -1719,19 +1874,8 @@ VectorResult VectorEffect::GetVectorResult()
 		if (Data->MaxSpeed >= 0 && speed > Data->MaxSpeed)
 			speed = static_cast<double>(Data->MaxSpeed);
 
-		// SpeedEndOnReach=no：不走影子系统，全程旧版 dirVec/dirLen 直追（自然产生抽搐跟随）
-		if (!Data->SpeedEndOnReach)
-		{
-			if (dirLen > 1e-6)
-			{
-				resultDisp.X = static_cast<int>(dirVec.X / dirLen * speed);
-				resultDisp.Y = static_cast<int>(dirVec.Y / dirLen * speed);
-				resultDisp.Z = static_cast<int>(dirVec.Z / dirLen * speed);
-			}
-			result.MoveDisp = resultDisp;
-			AdvanceFrame();
-			return result;
-		}
+		// SpeedEndOnReach=yes/no 都走影子系统：弧线（影子坐标弧高）不依赖 SpeedEndOnReach；
+		// no 时不做到达瞬移，继续追踪直到引擎自然触地爆炸
 
 		// 以下：SpeedEndOnReach=yes，走影子系统
 		// 有弧线：影子追踪完整 3D，弧高增量叠加
@@ -1751,36 +1895,54 @@ VectorResult VectorEffect::GetVectorResult()
 		}
 
 		// SpeedEndOnReach：瞬移到目标位置，引擎正常到达检测会自然引爆（不手动Detonate，避免重复伤害）
-		if (Data->SpeedEndOnReach && shadowDist <= speed)
+		// 到达判定用真实 3D 距离（含 Z），避免高空俯冲时 XY 先对齐导致误判到达
+		if (Data->SpeedEndOnReach)
 		{
-			if (pBullet)
+			double realDX = frameTarget.X - currentPos.X;
+			double realDY = frameTarget.Y - currentPos.Y;
+			double realDZ = frameTarget.Z - currentPos.Z;
+			double realDist = std::sqrt(realDX * realDX + realDY * realDY + realDZ * realDZ);
+			if (realDist <= speed)
 			{
-				pBullet->SetLocation(frameTarget);
+				if (pBullet)
+				{
+					pBullet->SetLocation(frameTarget);
+					// 零位移：位置已由 SetLocation 设定，不再让 Vector.cpp 回退
+					result.MoveDisp = { 0, 0, 0 };
+					result.Force = false;
+				}
+				else if (pTechno)
+				{
+					// 单位侧：位移 = 剩余距离，一步到位（Vector.cpp 会 SetLocation 到 frameTarget）
+					result.MoveDisp.X = frameTarget.X - currentPos.X;
+					result.MoveDisp.Y = frameTarget.Y - currentPos.Y;
+					result.MoveDisp.Z = frameTarget.Z - currentPos.Z;
+					result.Force = true;
+				}
+				Deactivate();
+				AdvanceFrame();
+				return result;
 			}
-			// 零位移：位置已由 SetLocation 设定，不再让 Vector.cpp 回退
-			result.MoveDisp = { 0, 0, 0 };
-			result.Force = false;
-			Deactivate();
-			AdvanceFrame();
-			return result;
 		}
 
 		if (shadowDist > 1e-6)
 		{
-			// 影子沿 shadow→target 方向推进
+			// 影子沿 shadow→target 方向推进，步长钳位到剩余距离：
+			// 末段 speed > 剩余距离时若仍推进满 speed 会越过目标，sdx 变号导致来回振荡（原地抽搐）
+			double step = (speed < shadowDist) ? speed : shadowDist;
 			double sInv = 1.0 / shadowDist;
-			double shadowStepX = sdx * sInv * speed;
-			double shadowStepY = sdy * sInv * speed;
+			double shadowStepX = sdx * sInv * step;
+			double shadowStepY = sdy * sInv * step;
 			double shadowStepZ = 0.0;
 			_shadowPosX += shadowStepX;
 			_shadowPosY += shadowStepY;
 			if (_arcHeight != 0)
 			{
-				shadowStepZ = sdz * sInv * speed;
+				shadowStepZ = sdz * sInv * step;
 				_shadowPosZ += shadowStepZ;
 			}
 			// 无弧线：_shadowPosZ 不变（始终 = _initialLocation.Z），Z 由 t 插值
-			_shadowTraveled += speed;
+			_shadowTraveled += step;
 
 			// 重新计算影子距离（影子已移动）
 			sdx = frameTarget.X - _shadowPosX;

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -228,7 +228,7 @@ void VectorEffect::OnStart()
 			}
 			_facingRad = std::atan2(dy, dx);
 			double lenXY = std::sqrt(dx * dx + dy * dy);
-			_tiltRad = (lenXY > 1e-6 && Data->AllowedTilt) ? std::atan2(dz, lenXY) : 0.0;
+			_tiltRad = (lenXY > 1e-6 && Data->AllowCircleTilt) ? std::atan2(dz, lenXY) : 0.0;
 		}
 		break;
 	}
@@ -252,7 +252,7 @@ void VectorEffect::OnStart()
 			}
 			_facingRad = std::atan2(dy, dx);
 			double lenXY = std::sqrt(dx * dx + dy * dy);
-			_tiltRad = (lenXY > 1e-6 && Data->AllowedTilt) ? std::atan2(dz, lenXY) : 0.0;
+			_tiltRad = (lenXY > 1e-6 && Data->AllowCircleTilt) ? std::atan2(dz, lenXY) : 0.0;
 		}
 		break;
 	}
@@ -339,7 +339,7 @@ VectorResult VectorEffect::GetVectorResult()
 
 	// AllowOriginTilt：从 Origin 单位获取倾斜，注入 _facingRad/_tiltRad（同 NormalVector 机制）
 	double originTerrainTilt = 0.0;
-	if (Data->AllowOriginTilt && !Data->OriginIsOnWorld)
+	if ((Data->AllowOriginTilt || Data->OriginAllowOriginTilt) && !Data->OriginIsOnWorld)
 	{
 		TechnoClass* pOriginTechno = nullptr;
 		switch (Data->Origin)
@@ -421,7 +421,7 @@ VectorResult VectorEffect::GetVectorResult()
 				double dy = currentPos.Y - _pSource->GetCoords().Y;
 				double dz = currentPos.Z - _pSource->GetCoords().Z;
 				double lenXY = std::sqrt(dx*dx + dy*dy);
-				effectiveTilt = (lenXY > 1e-6 && Data->AllowedTilt) ? std::atan2(dz, lenXY) : 0.0;
+				effectiveTilt = (lenXY > 1e-6 && Data->AllowCircleTilt) ? std::atan2(dz, lenXY) : 0.0;
 			}
 			break;
 		case VectorData::VectorOrigin::Target:
@@ -442,7 +442,7 @@ VectorResult VectorEffect::GetVectorResult()
 			effectiveFacing = mainFacingDir.GetRadian();
 			double dx = currentPos.X - targetPos.X, dy = currentPos.Y - targetPos.Y, dz = currentPos.Z - targetPos.Z;
 			double lenXY = std::sqrt(dx*dx + dy*dy);
-			effectiveTilt = (lenXY > 1e-6 && Data->AllowedTilt) ? std::atan2(dz, lenXY) : 0.0;
+			effectiveTilt = (lenXY > 1e-6 && Data->AllowCircleTilt) ? std::atan2(dz, lenXY) : 0.0;
 		}
 			break;
 
@@ -752,6 +752,22 @@ VectorResult VectorEffect::GetVectorResult()
 				{
 					_originFacing = 0;
 					_originTilt = M_PI / 2.0;
+					// OriginAllowCircleTilt: 大圆面跟随目标倾斜（Origin=Target 时有效）
+					if (Data->OriginAllowCircleTilt && Data->OriginOrigin == VectorData::VectorOrigin::Target)
+					{
+						CoordStruct targetPos {};
+						bool hasTargetPos = false;
+						if (pBullet) { targetPos = pBullet->TargetCoords; hasTargetPos = true; }
+						else if (pTechno && pTechno->Target) { targetPos = pTechno->Target->GetCoords(); hasTargetPos = true; }
+						if (hasTargetPos)
+						{
+							double dx = circleCenter.X - targetPos.X;
+							double dy = circleCenter.Y - targetPos.Y;
+							double dz = circleCenter.Z - targetPos.Z;
+							double lenXY = std::sqrt(dx * dx + dy * dy);
+							_originTilt = (lenXY > 1e-6) ? std::atan2(dz, lenXY) : M_PI / 2.0;
+						}
+					}
 				}
 				else
 				{
@@ -787,8 +803,25 @@ VectorResult VectorEffect::GetVectorResult()
 			_originNormalRotL += _originNormalStepL;
 			_originNormalRotH += _originNormalStepH;
 
+			// OriginAllowCircleTilt：每帧从目标 Z 差更新大圆面倾斜
+			if (Data->OriginAllowCircleTilt && Data->OriginOrigin == VectorData::VectorOrigin::Target)
+			{
+				CoordStruct oc = baseCenter + _originOffset;
+				CoordStruct targetPos {};
+				bool hasTargetPos = false;
+				if (pBullet) { targetPos = pBullet->TargetCoords; hasTargetPos = true; }
+				else if (pTechno && pTechno->Target) { targetPos = pTechno->Target->GetCoords(); hasTargetPos = true; }
+				if (hasTargetPos)
+				{
+					double dx = oc.X - targetPos.X, dy = oc.Y - targetPos.Y, dz = oc.Z - targetPos.Z;
+					double lenXY = std::sqrt(dx * dx + dy * dy);
+					_originTilt = (lenXY > 1e-6) ? std::atan2(dz, lenXY) : M_PI / 2.0;
+				}
+			}
+
 			double oFacing = _originFacing + Math::deg2rad(_originNormalRotH);
-			double oTilt = _originTilt + Math::deg2rad(_originNormalRotL);
+			double oTilt = _originTilt + Math::deg2rad(_originNormalRotL)
+				+ (Data->OriginAllowOriginTilt ? originTerrainTilt : 0.0);
 			DirStruct oFacingDir = Radians2Dir(oFacing); // 官方API，不得修改：弧度→DirStruct
 
 			// 当前圆心绝对位置 = 基座 + 偏移
@@ -930,8 +963,7 @@ VectorResult VectorEffect::GetVectorResult()
 	double dy = static_cast<double>(trackPos.Y - circleCenter.Y);
 	double dz = static_cast<double>(trackPos.Z - circleCenter.Z);
 		double currentDist;
-		bool useTiltPlane = hasNormal || (Data->AllowedTilt && effectiveTilt != 0.0)
-			|| (Data->AllowOriginTilt && originTerrainTilt != 0.0);
+		bool useTiltPlane = hasNormal || (Data->AllowCircleTilt && effectiveTilt != 0.0);
 		if (useTiltPlane)
 		{
 			// 倾斜圆面：投影到 LH 平面计算当前距离
@@ -1027,7 +1059,7 @@ VectorResult VectorEffect::GetVectorResult()
 		// Origin=Target：F 轴应以 抛射体→目标 连线为准（含 Z 落差），而非全局的 target→抛射体
 		if (Data->Origin == VectorData::VectorOrigin::Target)
 		{
-			CoordStruct tgt;
+			CoordStruct tgt {};
 			bool hasTgt = false;
 			if (pBullet && pBullet->Target)
 				{ tgt = pBullet->Target->GetCoords(); hasTgt = true; }
@@ -1044,7 +1076,7 @@ VectorResult VectorEffect::GetVectorResult()
 				if (tLenXY > 1e-6)
 				{
 					moveDir = Radians2Dir(std::atan2(tdy, tdx)); // 官方API，不得修改
-					if (Data->AllowedTilt)
+					if (Data->AllowCircleTilt)
 					{
 						double tLen3D = std::sqrt(tdx * tdx + tdy * tdy + tdz * tdz);
 						useCosT = tLenXY / tLen3D;
@@ -1072,9 +1104,9 @@ VectorResult VectorEffect::GetVectorResult()
 		{
 			double mf = moveDir.GetRadian();
 			double cosF = std::cos(mf), sinF = std::sin(mf);
-			double cosT = (Data->Origin == VectorData::VectorOrigin::Target && Data->AllowedTilt)
+			double cosT = (Data->Origin == VectorData::VectorOrigin::Target && Data->AllowCircleTilt)
 				? useCosT : std::cos(effectiveTilt);
-			double sinT = (Data->Origin == VectorData::VectorOrigin::Target && Data->AllowedTilt)
+			double sinT = (Data->Origin == VectorData::VectorOrigin::Target && Data->AllowCircleTilt)
 				? useSinT : std::sin(effectiveTilt);
 			double F = static_cast<double>(moveFlh.X);
 			double L = static_cast<double>(moveFlh.Y);

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -10,6 +10,8 @@
 
 #include <Ext/ObjectType/AttachEffect.h>
 #include <Ext/EffectType/AttachEffectScript.h>
+
+std::map<TechnoClass*, CoordStruct> VectorEffect::_lastTargetCache;
 #include <Ext/BulletType/BulletStatus.h>
 
 
@@ -208,10 +210,30 @@ void VectorEffect::OnStart()
 	case VectorData::VectorOrigin::Target:
 		if (Data->OriginNoUpdate)
 		{
-			// 对标 AutoWeapon IsOnTarget: 锚点是目标单位自身，不是 pTechno->Target
-			if (pTechno)
+			// 锚点 = 原定目标：攻击目标 → 移动目标(Destination) → 焦点(Focus) → 缓存 → 自身
+			if (pTechno && pTechno->Target)
+				_initialOriginPos = pTechno->Target->GetCoords();
+			else if (pTechno)
 			{
-				_initialOriginPos = pTechno->GetCoords();
+				FootClass* pFoot = abstract_cast<FootClass*>(pTechno);
+				if (pFoot && pFoot->Destination)
+				{
+					_initialOriginPos = pFoot->Destination->GetCoords();
+					_lastTargetCache[pTechno] = _initialOriginPos;
+				}
+				else if (pTechno->Focus)
+				{
+					_initialOriginPos = pTechno->Focus->GetCoords();
+					_lastTargetCache[pTechno] = _initialOriginPos;
+				}
+				else
+				{
+					auto it = _lastTargetCache.find(pTechno);
+					if (it != _lastTargetCache.end())
+						_initialOriginPos = it->second;
+					else
+						_initialOriginPos = pObject->GetCoords();
+				}
 			}
 			else if (pBullet)
 				_initialOriginPos = pBullet->TargetCoords;
@@ -339,13 +361,11 @@ void VectorEffect::OnStart()
 	{
 		if (!hasNormal)
 		{
-			// 照搬 AutoWeapon GetSourcePosOnTarget:
-			// facingDir = Point2Dir(sourcePos, targetPos)  → attacker→target (RA2)
-			// 锚点 = targetPos（目标单位自身坐标）
-			if (pTechno && AE && AE->pSource)
+			// 射手角色 = 附着对象自身；F 轴 = Point2Dir(攻击目标, 弹体)。无攻击目标不锁定（保持默认朝向）
+			if (pTechno && pTechno->Target)
 			{
-				CoordStruct targetPos = pTechno->GetCoords();
-				CoordStruct sourcePos = AE->pSource->GetCoords();
+				CoordStruct targetPos = pTechno->Target->GetCoords();
+				CoordStruct sourcePos = pTechno->GetCoords(); // 射手角色 = 自身
 				_facingDir = Point2Dir(targetPos, sourcePos); // 官方API，不得修改
 				_facingRad = _facingDir.GetRadian();
 			}
@@ -393,6 +413,10 @@ void VectorEffect::OnStart()
 VectorResult VectorEffect::GetVectorResult()
 {
 	VectorResult result;
+
+	if (Data->ReachTarget)
+		Debug::Log("[VectorG] enter el=%d moveF=%d mf=%d total=%d ts=%d started=%d\n",
+			_elapsedFrames, _moveFrame, _movementFrames, _totalDuration, _effectiveTimeStep, (int)_started);
 
 	// 首帧快照（仅一次，供弧高计算等）
 	if (_elapsedFrames == 0)
@@ -469,6 +493,22 @@ VectorResult VectorEffect::GetVectorResult()
 		return result;
 	}
 	_movementFrames++;
+
+	// 每帧更新缓存：即使 OnStart 时 Target 为空，后续帧获取后也能传递
+	if (pTechno)
+	{
+		CoordStruct cached;
+		bool got = false;
+		if (pTechno->Target) { cached = pTechno->Target->GetCoords(); got = true; }
+		else
+		{
+			FootClass* pf = abstract_cast<FootClass*>(pTechno);
+			if (pf && pf->Destination) { cached = pf->Destination->GetCoords(); got = true; }
+			else if (pTechno->Focus) { cached = pTechno->Focus->GetCoords(); got = true; }
+		}
+		if (got)
+			_lastTargetCache[pTechno] = cached;
+	}
 
 	_normalRotF += _lissajousStep;
 	// 3D 法向量增量旋转（绕世界 F=Y / L=X / H=Z 轴，正速度=顺时针）
@@ -591,11 +631,16 @@ VectorResult VectorEffect::GetVectorResult()
 		case VectorData::VectorOrigin::Source:
 			if (_pSource && !IsDeadOrInvisible(_pSource))
 			{
-				mainFacingDir = Point2Dir(_pSource->GetCoords(), currentPos); // 官方API，不得修改
+				_initialOriginPos = _pSource->GetCoords(); // 来源活着：每帧更新快照
+			}
+			if (!_initialOriginPos.IsEmpty())
+			{
+				// 来源活着或已死亡：都用快照算朝向（死亡后冻结指向死亡点）
+				mainFacingDir = Point2Dir(_initialOriginPos, currentPos); // 官方API，不得修改
 				effectiveFacing = mainFacingDir.GetRadian();
-				double dx = currentPos.X - _pSource->GetCoords().X;
-				double dy = currentPos.Y - _pSource->GetCoords().Y;
-				double dz = currentPos.Z - _pSource->GetCoords().Z;
+				double dx = currentPos.X - _initialOriginPos.X;
+				double dy = currentPos.Y - _initialOriginPos.Y;
+				double dz = currentPos.Z - _initialOriginPos.Z;
 				double lenXY = std::sqrt(dx*dx + dy*dy);
 				effectiveTilt = (lenXY > 1e-6 && Data->AllowCircleTilt) ? std::atan2(dz, lenXY) : 0.0;
 			}
@@ -607,13 +652,56 @@ VectorResult VectorEffect::GetVectorResult()
 				break;
 			CoordStruct targetPos;
 			if (pBullet && pBullet->Target)
-				targetPos = pBullet->Target->GetCoords();
+			{
+				// 地面目标（Cell，非 ObjectClass）永远有效；单位目标死亡才冻结
+				ObjectClass* pTgtObj = abstract_cast<ObjectClass*>(pBullet->Target);
+				if (!pTgtObj || !IsDeadOrInvisible(pTgtObj))
+				{
+					_initialOriginPos = pBullet->Target->GetCoords(); // 目标有效：更新快照
+					targetPos = _initialOriginPos;
+				}
+				else
+					targetPos = _initialOriginPos.IsEmpty() ? pBullet->TargetCoords : _initialOriginPos; // 单位目标死亡：冻结
+			}
 			else if (pBullet)
-				targetPos = pBullet->TargetCoords;
+				targetPos = _initialOriginPos.IsEmpty() ? pBullet->TargetCoords : _initialOriginPos; // 无 Target：地面落点/冻结快照
 			else if (pTechno && pTechno->Target)
-				targetPos = pTechno->Target->GetCoords();
-			else if (pTechno && AE && AE->pSource)
-				targetPos = AE->pSource->GetCoords(); // 对标 AutoWeapon: 攻击者位置
+			{
+				// 地面目标（Cell，非 ObjectClass）永远有效；单位目标死亡才冻结
+				ObjectClass* pTgtObj = abstract_cast<ObjectClass*>(pTechno->Target);
+				if (!pTgtObj || !IsDeadOrInvisible(pTgtObj))
+				{
+					_initialOriginPos = pTechno->Target->GetCoords(); // 目标有效：更新快照
+					targetPos = _initialOriginPos;
+				}
+				else
+					targetPos = _initialOriginPos.IsEmpty() ? currentPos : _initialOriginPos; // 单位目标死亡：冻结
+			}
+			else if (pTechno)
+			{
+				if (!_initialOriginPos.IsEmpty())
+				{
+					// 目标死亡：冻结死亡坐标，朝向保持指向死亡点
+					targetPos = _initialOriginPos;
+				}
+				else
+				{
+					// 从未有过目标：回退移动目标(Destination) → 焦点(Focus) → 缓存，都没有则什么都不做（保持朝向）
+					FootClass* pFoot = abstract_cast<FootClass*>(pTechno);
+					if (pFoot && pFoot->Destination)
+						targetPos = pFoot->Destination->GetCoords();
+					else if (pTechno->Focus)
+						targetPos = pTechno->Focus->GetCoords();
+					else
+					{
+						auto it = _lastTargetCache.find(pTechno);
+						if (it != _lastTargetCache.end())
+							targetPos = it->second;
+						else
+							break;
+					}
+				}
+			}
 			else
 				break;
 			mainFacingDir = Point2Dir(targetPos, currentPos); // 官方API，不得修改
@@ -675,21 +763,60 @@ VectorResult VectorEffect::GetVectorResult()
 		if (Data->OriginNoUpdate)
 			originPos = _initialOriginPos;
 		else if (pBullet && pBullet->Target)
-			originPos = pBullet->Target->GetCoords(); // 单位：实时跟踪
+		{
+			// 地面目标（Cell，非 ObjectClass）永远有效；单位目标死亡才冻结
+			ObjectClass* pTgtObj = abstract_cast<ObjectClass*>(pBullet->Target);
+			if (!pTgtObj || !IsDeadOrInvisible(pTgtObj))
+			{
+				_initialOriginPos = pBullet->Target->GetCoords(); // 目标有效：每帧更新快照
+				originPos = _initialOriginPos;
+			}
+			else
+				originPos = _initialOriginPos.IsEmpty() ? pBullet->TargetCoords : _initialOriginPos; // 单位目标死亡：冻结
+		}
 		else if (pBullet)
-			originPos = pBullet->TargetCoords;         // 地面：自动锁定
-		else if (pTechno)
-			originPos = pTechno->GetCoords();           // 对标 AutoWeapon: 目标单位自身
+			originPos = _initialOriginPos.IsEmpty() ? pBullet->TargetCoords : _initialOriginPos; // 无 Target：地面落点/冻结快照
+		else if (pTechno && pTechno->Target)
+		{
+			// 地面目标（Cell，非 ObjectClass）永远有效；单位目标死亡才冻结
+			ObjectClass* pTgtObj = abstract_cast<ObjectClass*>(pTechno->Target);
+			if (!pTgtObj || !IsDeadOrInvisible(pTgtObj))
+			{
+				_initialOriginPos = pTechno->Target->GetCoords(); // 目标有效：每帧更新快照
+				originPos = _initialOriginPos;
+			}
+			else
+				originPos = _initialOriginPos.IsEmpty() ? currentPos : _initialOriginPos; // 单位目标死亡：冻结死亡坐标
+		}
 		else
-			originPos = currentPos;
+		{
+			// 无 Target：实例快照 → 全局缓存 → 自身
+			if (!_initialOriginPos.IsEmpty())
+				originPos = _initialOriginPos;
+			else
+			{
+				auto it = _lastTargetCache.find(pTechno);
+				if (it != _lastTargetCache.end())
+					originPos = it->second;
+				else
+					originPos = currentPos;
+			}
+		}
 		break;
 	case VectorData::VectorOrigin::Launcher:
 		originPos = Data->OriginNoUpdate ? _initialOriginPos :
 			(_pLauncher && !IsDeadOrInvisible(_pLauncher) ? _pLauncher->GetCoords() : currentPos);
 		break;
 	case VectorData::VectorOrigin::Source:
-		originPos = Data->OriginNoUpdate ? _initialOriginPos :
-			(_pSource && !IsDeadOrInvisible(_pSource) ? _pSource->GetCoords() : currentPos);
+		if (Data->OriginNoUpdate)
+			originPos = _initialOriginPos;
+		else if (_pSource && !IsDeadOrInvisible(_pSource))
+		{
+			_initialOriginPos = _pSource->GetCoords(); // 来源活着：每帧更新快照
+			originPos = _initialOriginPos;
+		}
+		else
+			originPos = _initialOriginPos.IsEmpty() ? currentPos : _initialOriginPos; // 来源死亡：冻结死亡坐标
 		break;
 	case VectorData::VectorOrigin::Self:
 		originPos = Data->OriginNoUpdate ? _initialOriginPos : currentPos;
@@ -1479,30 +1606,33 @@ VectorResult VectorEffect::GetVectorResult()
 			int effectiveDuration = _totalDuration - Data->DisabledFrames;
 		if (effectiveDuration < 1) effectiveDuration = 1;
 		int remainingFrames = effectiveDuration - _movementFrames + 1;
+		AbstractClass* pRealTarget = pBullet ? pBullet->Target : (pTechno ? pTechno->Target : nullptr);
+		ObjectClass* pRealTargetObj = pRealTarget ? abstract_cast<ObjectClass*>(pRealTarget) : nullptr;
+		Debug::Log("[VectorReach] mf=%d rem=%d eff=%d cur=(%d,%d,%d) frameTarget=(%d,%d,%d)\n"
+			"  originPos=(%d,%d,%d) realTarget=%p what=%d alive=%d tgtPos=(%d,%d,%d)\n",
+			_movementFrames, remainingFrames, effectiveDuration,
+			currentPos.X, currentPos.Y, currentPos.Z,
+			frameTarget.X, frameTarget.Y, frameTarget.Z,
+			originPos.X, originPos.Y, originPos.Z,
+			(void*)pRealTarget,
+			pRealTarget ? (int)pRealTarget->WhatAmI() : -1,
+			pRealTargetObj ? (int)IsDeadOrInvisible(pRealTargetObj) : -1,
+			pRealTarget ? pRealTarget->GetCoords().X : 0,
+			pRealTarget ? pRealTarget->GetCoords().Y : 0,
+			pRealTarget ? pRealTarget->GetCoords().Z : 0);
 		if (Data->ReachTargetEarlyEnd > 0 && Data->ReachTargetEarlyEnd < effectiveDuration
 			&& remainingFrames <= Data->ReachTargetEarlyEnd)
 		{
+			Debug::Log("[VectorReach] EARLYEND rem=%d\n", remainingFrames);
 			Deactivate();
 			AdvanceFrame();
 			return result;
 		}
-		if (remainingFrames <= 0)
+		if (dirLen > 1e-6)
 		{
-			// 已超时：瞬移到目标，引擎正常到达检测会自然引爆
-			if (Data->Force && pBullet)
-			{
-				pBullet->SetLocation(frameTarget);
-				result.MoveDisp = { 0, 0, 0 };
-				result.Force = false;
-				Deactivate();
-				AdvanceFrame();
-				return result;
-			}
-			// Force=no 或无 pBullet：不设位移，自然结束
-		}
-		else if (dirLen > 1e-6)
-		{
-			double adjustedSpeed = dirLen / remainingFrames;
+			// AE 根基缺陷：Duration=N 实际只执行 N-1 个运动帧（末帧 AE 已移除）
+			// 轨迹按"实际帧数 = 总帧数 - 1"均分，保证 AE 实际删除的那一帧恰好到位
+			double adjustedSpeed = dirLen / (remainingFrames > 1 ? remainingFrames - 1 : 1);
 			resultDisp.X = static_cast<int>(dirVec.X / dirLen * adjustedSpeed);
 			resultDisp.Y = static_cast<int>(dirVec.Y / dirLen * adjustedSpeed);
 			resultDisp.Z = static_cast<int>(dirVec.Z / dirLen * adjustedSpeed);
@@ -1512,7 +1642,10 @@ VectorResult VectorEffect::GetVectorResult()
 			{
 				if (_arcStartLocation.IsEmpty())
 					_arcStartLocation = currentPos; // 首次弧线执行时抓取当前位置作为起点
-				double t = static_cast<double>(_movementFrames) / effectiveDuration;
+				// AE 根基缺陷（实际运动帧 = 总帧数-1）：t 按 mf 1..eff-1 映射 0..1，末帧到位
+				double t = (effectiveDuration > 2)
+					? static_cast<double>(_movementFrames - 1) / (effectiveDuration - 2)
+					: 1.0;
 				double arcOffset = CalcArcOffsetAt(t);
 				double baseX = _arcStartLocation.X + (frameTarget.X - _arcStartLocation.X) * t;
 				double baseY = _arcStartLocation.Y + (frameTarget.Y - _arcStartLocation.Y) * t;

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -1,5 +1,7 @@
 #include "VectorEffect.h"
 
+#include <Utilities/Debug.h>
+
 #include <Ext/Helper/Scripts.h>
 #include <Ext/Helper/Status.h>
 #include <Ext/Helper/Physics.h>
@@ -9,6 +11,9 @@
 #include <Ext/ObjectType/AttachEffect.h>
 #include <Ext/EffectType/AttachEffectScript.h>
 #include <Ext/BulletType/BulletStatus.h>
+
+// 跨 AE 链路目标坐标缓存
+std::map<TechnoClass*, CoordStruct> VectorEffect::_lastTargetCache;
 
 
 // Vector: Freeze / Circle / MoveTo / Speed / ReachTarget
@@ -22,18 +27,16 @@ void VectorEffect::OnStart()
 		return;
 	}
 
-	_active = true;
 	_elapsedFrames = 0;
 	_moveFrame = 0;
 	_movementFrames = 0;
 	_currentAngle = 0.0;
-	// _prevCirclePos = pObject->GetCoords();  // [DEAD] 从未读取
 	_effectiveTimeStep = Data->TimeStep;
 	// _prevCircleCenter 不在此初始化：圆心追踪依赖 Origin 移动系统首帧的 skipOriginUpdate 赋值
 
 	_initialLocation = pObject->GetCoords();
 	_vectorAcquireZ = _initialLocation.Z;  // Circle 圆心高度基准：获取 Vector 时的 Z
-	_totalDuration = AE->GetDuration() / _effectiveTimeStep;
+	_totalDuration = AE->AEData.GetDuration() / _effectiveTimeStep;
 
 	_randomTargetOffset.X = Random::RandomRanged(Data->TargetOffsetFMin, Data->TargetOffsetFMax);
 	_randomTargetOffset.Y = Random::RandomRanged(Data->TargetOffsetLMin, Data->TargetOffsetLMax);
@@ -110,14 +113,23 @@ void VectorEffect::OnStart()
 		_pLauncher = (AE && AE->pSource) ? AE->pSource : pTechno; // 单位侧用攻击者作为Launcher
 	}
 
+	// 缓存：只要单位有攻击目标就记录，不限Origin类型，供AE链路后续使用
+	if (pTechno && pTechno->Target)
+		_lastTargetCache[pTechno] = pTechno->Target->GetCoords();
+
 	// --- Origin 初始化 ---
 	switch (Data->Origin)
 	{
 	case VectorData::VectorOrigin::Target:
 		if (Data->OriginNoUpdate)
 		{
-			if (pTechno && pTechno->Target)
-				_initialOriginPos = pTechno->Target->GetCoords();
+			// 对标 AutoWeapon IsOnTarget: 锚点是目标单位自身，不是 pTechno->Target
+			if (pTechno)
+			{
+				_initialOriginPos = pTechno->GetCoords();
+				if (pTechno->Target)
+					_lastTargetCache[pTechno] = pTechno->Target->GetCoords();
+			}
 			else if (pBullet)
 				_initialOriginPos = pBullet->TargetCoords;
 			else
@@ -206,6 +218,17 @@ void VectorEffect::OnStart()
 	_normalStepF = resolveAngleStep(Data->NormalFAnglePerStep, Data->NormalFAngleRMin, Data->NormalFAngleRMax, Data->NormalFAngleRMin2, Data->NormalFAngleRMax2);
 	_normalStepL = resolveAngleStep(Data->NormalLAnglePerStep, Data->NormalLAngleRMin, Data->NormalLAngleRMax, Data->NormalLAngleRMin2, Data->NormalLAngleRMax2);
 	_normalStepH = resolveAngleStep(Data->NormalHAnglePerStep, Data->NormalHAngleRMin, Data->NormalHAngleRMax, Data->NormalHAngleRMin2, Data->NormalHAngleRMax2);
+	_lissajousStep = Data->Lissajous;
+
+	// 初始化 3D 法向量（从球坐标 _facingRad/_tiltRad 转换）
+	// 球坐标→笛卡尔：X=cos(tilt)cos(facing), Y=cos(tilt)sin(facing), Z=sin(tilt)
+	{
+		double ct = std::cos(_tiltRad), st = std::sin(_tiltRad);
+		double cf = std::cos(_facingRad), sf = std::sin(_facingRad);
+		_normalX = ct * cf;
+		_normalY = ct * sf;
+		_normalZ = st;
+	}
 
 	switch (Data->Origin)
 	{
@@ -214,7 +237,7 @@ void VectorEffect::OnStart()
 		if (!hasNormal)
 		{
 			TechnoClass* pLauncherTechno = abstract_cast<TechnoClass*>(_pLauncher);
-			if (pLauncherTechno)
+			if (pLauncherTechno && !IsDeadOrInvisible(pLauncherTechno))
 				_facingRad = pLauncherTechno->TurretFacing().Current().GetRadian();
 		}
 		break;
@@ -224,26 +247,23 @@ void VectorEffect::OnStart()
 	{
 		if (!hasNormal)
 		{
-			double dx = 0, dy = 0, dz = 0;
-			if (pTechno && pTechno->Target)
+			// 照搬 AutoWeapon GetSourcePosOnTarget:
+			// facingDir = Point2Dir(sourcePos, targetPos)  → attacker→target (RA2)
+			// 锚点 = targetPos（目标单位自身坐标）
+			if (pTechno && AE && AE->pSource)
 			{
-				CoordStruct targetPos = pTechno->Target->GetCoords();
-				CoordStruct selfPos = pTechno->GetCoords();
-				dx = selfPos.X - targetPos.X;
-				dy = selfPos.Y - targetPos.Y;
-				dz = selfPos.Z - targetPos.Z;
+				CoordStruct targetPos = pTechno->GetCoords();
+				CoordStruct sourcePos = AE->pSource->GetCoords();
+				_facingDir = Point2Dir(targetPos, sourcePos); // 官方API，不得修改
+				_facingRad = _facingDir.GetRadian();
 			}
 			else if (pBullet)
 			{
 				CoordStruct bulletPos = pBullet->GetCoords();
 				CoordStruct targetPos = pBullet->TargetCoords;
-				dx = bulletPos.X - targetPos.X;
-				dy = bulletPos.Y - targetPos.Y;
-				dz = bulletPos.Z - targetPos.Z;
+				_facingDir = Point2Dir(targetPos, bulletPos); // 官方API，不得修改
+				_facingRad = _facingDir.GetRadian();
 			}
-			_facingRad = std::atan2(dy, dx);
-			double lenXY = std::sqrt(dx * dx + dy * dy);
-			_tiltRad = (lenXY > 1e-6 && Data->AllowCircleTilt) ? std::atan2(dz, lenXY) : 0.0;
 		}
 		break;
 	}
@@ -252,22 +272,16 @@ void VectorEffect::OnStart()
 	{
 		if (!hasNormal)
 		{
-			double dx = 0, dy = 0, dz = 0;
 			if (pBullet && AE && AE->pSource)
 			{
-				CoordStruct srcPos = AE->pSource->GetCoords();
-				CoordStruct objPos = pBullet->GetCoords();
-				dx = objPos.X - srcPos.X; dy = objPos.Y - srcPos.Y; dz = objPos.Z - srcPos.Z;
+				_facingDir = Point2Dir(pBullet->GetCoords(), AE->pSource->GetCoords()); // 官方API
+				_facingRad = _facingDir.GetRadian();
 			}
 			else if (pTechno && AE && AE->pSource)
 			{
-				CoordStruct srcPos = AE->pSource->GetCoords();
-				CoordStruct objPos = pTechno->GetCoords();
-				dx = objPos.X - srcPos.X; dy = objPos.Y - srcPos.Y; dz = objPos.Z - srcPos.Z;
+				_facingDir = Point2Dir(pTechno->GetCoords(), AE->pSource->GetCoords()); // 官方API
+				_facingRad = _facingDir.GetRadian();
 			}
-			_facingRad = std::atan2(dy, dx);
-			double lenXY = std::sqrt(dx * dx + dy * dy);
-			_tiltRad = (lenXY > 1e-6 && Data->AllowCircleTilt) ? std::atan2(dz, lenXY) : 0.0;
 		}
 		break;
 	}
@@ -281,6 +295,23 @@ void VectorEffect::OnStart()
 		break;
 	}
 	}
+
+	// === DEBUG: Origin=Target coordinate diagnostics ===
+	{
+		const char* originStr = "Unknown";
+		switch (Data->Origin)
+		{
+		case VectorData::VectorOrigin::Target:  originStr = "Target";  break;
+		case VectorData::VectorOrigin::Launcher:originStr = "Launcher";break;
+		case VectorData::VectorOrigin::Source:  originStr = "Source";  break;
+		case VectorData::VectorOrigin::Self:    originStr = "Self";    break;
+		default:                                originStr = "FLH";     break;
+		}
+		Debug::Log("[VectorOnStart] Origin=%s NoUpdate=%d IsOnWorld=%d\n", originStr, (int)Data->OriginNoUpdate, (int)Data->OriginIsOnWorld);
+		Debug::Log("  _initialOriginPos = (%d, %d, %d)\n", _initialOriginPos.X, _initialOriginPos.Y, _initialOriginPos.Z);
+		Debug::Log("  _facingRad        = %.4f rad  (%.1f deg)\n", _facingRad, _facingRad * 180.0 / M_PI);
+	}
+	// === END DEBUG ===
 }
 
 VectorResult VectorEffect::GetVectorResult()
@@ -338,13 +369,47 @@ VectorResult VectorEffect::GetVectorResult()
 	}
 	_movementFrames++;
 
-	// [REDUNDANT] 此处 ShouldMoveThisFrame() 必定为 true（310行已 return）
-	// if (ShouldMoveThisFrame())
-	// {
-		_normalRotF += _normalStepF;
-		_normalRotL += _normalStepL;
-		_normalRotH += _normalStepH;
-	// }
+	// 每帧更新缓存：即使OnStart时Target为空，后续帧获取后也能传递
+	if (pTechno)
+	{
+		CoordStruct cached{};
+		bool got = false;
+		if (pTechno->Target) { cached = pTechno->Target->GetCoords(); got = true; }
+		else {
+			FootClass* pf = abstract_cast<FootClass*>(pTechno);
+			if (pf && pf->Destination) { cached = pf->Destination->GetCoords(); got = true; }
+			else if (pTechno->Focus) { cached = pTechno->Focus->GetCoords(); got = true; }
+		}
+		if (got)
+			_lastTargetCache[pTechno] = cached;
+	}
+
+	_normalRotF += _lissajousStep;
+	// 3D 法向量增量旋转（绕世界 F=Y / L=X / H=Z 轴，正速度=顺时针）
+		if (_normalStepF != 0.0 || _normalStepL != 0.0 || _normalStepH != 0.0)
+		{
+			if (_normalStepF != 0.0)
+			{
+				double rad = Math::deg2rad(_normalStepF), c = std::cos(rad), s = std::sin(rad);
+				double nx = _normalX, nz = _normalZ;
+				_normalX = nx * c - nz * s;
+				_normalZ = nx * s + nz * c;
+			}
+			if (_normalStepL != 0.0)
+			{
+				double rad = Math::deg2rad(_normalStepL), c = std::cos(rad), s = std::sin(rad);
+				double ny = _normalY, nz = _normalZ;
+				_normalY = ny * c + nz * s;
+				_normalZ = -ny * s + nz * c;
+			}
+			if (_normalStepH != 0.0)
+			{
+				double rad = Math::deg2rad(_normalStepH), c = std::cos(rad), s = std::sin(rad);
+				double nx = _normalX, ny = _normalY;
+				_normalX = nx * c + ny * s;
+				_normalY = -nx * s + ny * c;
+			}
+		}
 
 	CoordStruct currentPos = pObject->GetCoords();
 
@@ -353,8 +418,10 @@ VectorResult VectorEffect::GetVectorResult()
 	// ========================================================================
 
 	// AllowOriginTilt：从 Origin 单位获取倾斜，注入 _facingRad/_tiltRad（同 NormalVector 机制）
+	// 仅 Circle 模式生效，避免非 Circle 模式覆盖 OnStart 的方向
 	double originTerrainTilt = 0.0;
-	if ((Data->AllowOriginTilt || Data->OriginAllowOriginTilt) && !Data->OriginIsOnWorld)
+	bool hasCircleForTilt = Data->CircleRadius > 0 || Data->CircleAnglePerStep > 0.0;
+	if ((Data->AllowOriginTilt || Data->OriginAllowOriginTilt) && hasCircleForTilt && !Data->OriginIsOnWorld)
 	{
 		TechnoClass* pOriginTechno = nullptr;
 		switch (Data->Origin)
@@ -407,9 +474,21 @@ VectorResult VectorEffect::GetVectorResult()
 		}
 	}
 
-	double effectiveFacing = _facingRad + Math::deg2rad(_normalRotH);
-	double effectiveTilt = _tiltRad + Math::deg2rad(_normalRotL);
+	double effectiveFacing = _facingRad;
+	double effectiveTilt = _tiltRad;
 	DirStruct mainFacingDir = Radians2Dir(effectiveFacing); // 官方API，不得修改：引擎弧度→DirStruct转换
+	// OriginNoUpdate + Target/Source：直接用 OnStart 的 Point2Dir 结果，不经 GetRadian→Radians2Dir 往返
+	if (Data->OriginNoUpdate && (Data->Origin == VectorData::VectorOrigin::Target || Data->Origin == VectorData::VectorOrigin::Source))
+	{
+		mainFacingDir = _facingDir;
+		effectiveFacing = _facingDir.GetRadian();
+		Debug::Log("[VectorMFD_override] _facingDir.Raw=%u  mainFacingDir.Raw=%u  GetRadian=%.4f\n",
+			(unsigned)_facingDir.Raw, (unsigned)mainFacingDir.Raw, mainFacingDir.GetRadian());
+	}
+	Debug::Log("[VectorMFD_init] effectiveFacing=%.4f rad (%.1f deg)  raw=%-5u  GetRadian=%.4f rad (%.1f deg)\n",
+		effectiveFacing, effectiveFacing * 180.0 / M_PI,
+		(unsigned)mainFacingDir.Raw,
+		mainFacingDir.GetRadian(), mainFacingDir.GetRadian() * 180.0 / M_PI);
 
 	// OriginIsOnWorld：锁定世界坐标系（朝北），覆盖 Origin 朝向
 	if (Data->OriginIsOnWorld)
@@ -451,6 +530,8 @@ VectorResult VectorEffect::GetVectorResult()
 				targetPos = pBullet->TargetCoords;
 			else if (pTechno && pTechno->Target)
 				targetPos = pTechno->Target->GetCoords();
+			else if (pTechno && AE && AE->pSource)
+				targetPos = AE->pSource->GetCoords(); // 对标 AutoWeapon: 攻击者位置
 			else
 				break;
 			mainFacingDir = Point2Dir(targetPos, currentPos); // 官方API，不得修改
@@ -492,6 +573,15 @@ VectorResult VectorEffect::GetVectorResult()
 		}
 	}
 
+	// 3D 法向量旋转覆盖：当 NormalF/L/HAnglePerStep 设定时，无视基座变化
+	if (_normalStepF != 0.0 || _normalStepL != 0.0 || _normalStepH != 0.0)
+	{
+		double lenXY = std::sqrt(_normalX * _normalX + _normalY * _normalY);
+		effectiveFacing = lenXY > 1e-6 ? std::atan2(_normalY, _normalX) : 0.0;
+		effectiveTilt = lenXY > 1e-6 ? std::atan2(_normalZ, lenXY) : (_normalZ > 0 ? M_PI / 2.0 : -M_PI / 2.0);
+		mainFacingDir = Radians2Dir(effectiveFacing); // 官方API，不得修改
+	}
+
 	// ========================================================================
 	// Origin 坐标
 	// ========================================================================
@@ -506,8 +596,8 @@ VectorResult VectorEffect::GetVectorResult()
 			originPos = pBullet->Target->GetCoords(); // 单位：实时跟踪
 		else if (pBullet)
 			originPos = pBullet->TargetCoords;         // 地面：自动锁定
-		else if (pTechno && pTechno->Target)
-			originPos = pTechno->Target->GetCoords();
+		else if (pTechno)
+			originPos = pTechno->GetCoords();           // 对标 AutoWeapon: 目标单位自身
 		else
 			originPos = currentPos;
 		break;
@@ -602,10 +692,6 @@ VectorResult VectorEffect::GetVectorResult()
 	CoordStruct adjustedCircleOrigin = Data->CircleOrigin;
 	if (!Data->CircleOrigin.IsEmpty())
 		adjustedCircleOrigin.Z = Data->OriginFLH.Z + Data->CircleOrigin.Z;
-	// else if (!Data->OriginFLH.IsEmpty())
-	//	adjustedCircleOrigin.Z = _vectorAcquireZ + Data->OriginFLH.Z;  // 废代码：adjustedCircleOrigin 后续不会被使用
-	// 注意：仅 OriginFLH 时 CircleOrigin 为空，不进入 GetFLHAbsoluteCoords 分支，
-	// 需要单独处理 Z（见下方 OriginFLH 偏移后覆盖）
 
 	CoordStruct circleCenter = originPos;
 
@@ -768,6 +854,7 @@ VectorResult VectorEffect::GetVectorResult()
 				_originNormalStepF = res(Data->OriginNormalFAnglePerStep, Data->OriginNormalFAngleRMin, Data->OriginNormalFAngleRMax, Data->OriginNormalFAngleRMin2, Data->OriginNormalFAngleRMax2);
 				_originNormalStepL = res(Data->OriginNormalLAnglePerStep, Data->OriginNormalLAngleRMin, Data->OriginNormalLAngleRMax, Data->OriginNormalLAngleRMin2, Data->OriginNormalLAngleRMax2);
 				_originNormalStepH = res(Data->OriginNormalHAnglePerStep, Data->OriginNormalHAngleRMin, Data->OriginNormalHAngleRMax, Data->OriginNormalHAngleRMin2, Data->OriginNormalHAngleRMax2);
+			_originLissajousStep = Data->OriginLissajous;
 			// 无 NormalVector 时：默认水平圆面（法向量朝上）
 				if (Data->OriginNormalVector.IsEmpty())
 				{
@@ -817,12 +904,41 @@ VectorResult VectorEffect::GetVectorResult()
 						break;
 					}
 				}
+				// 初始化大圆 3D 法向量
+				{
+					double ct = std::cos(_originTilt), st = std::sin(_originTilt);
+					double cf = std::cos(_originFacing), sf = std::sin(_originFacing);
+					_originNormalX = ct * cf;
+					_originNormalY = ct * sf;
+					_originNormalZ = st;
+				}
 			}
-
-			// 每帧累加 Normal 旋转
-			_originNormalRotF += _originNormalStepF;
-			_originNormalRotL += _originNormalStepL;
-			_originNormalRotH += _originNormalStepH;
+		// 每帧累加 Lissajous + 3D 法向量增量旋转
+		_originNormalRotF += _originLissajousStep;
+		if (_originNormalStepF != 0.0 || _originNormalStepL != 0.0 || _originNormalStepH != 0.0)
+		{
+			if (_originNormalStepF != 0.0)
+			{
+				double rad = Math::deg2rad(_originNormalStepF), c = std::cos(rad), s = std::sin(rad);
+				double nx = _originNormalX, nz = _originNormalZ;
+				_originNormalX = nx * c - nz * s;
+				_originNormalZ = nx * s + nz * c;
+			}
+			if (_originNormalStepL != 0.0)
+			{
+				double rad = Math::deg2rad(_originNormalStepL), c = std::cos(rad), s = std::sin(rad);
+				double ny = _originNormalY, nz = _originNormalZ;
+				_originNormalY = ny * c + nz * s;
+				_originNormalZ = -ny * s + nz * c;
+			}
+			if (_originNormalStepH != 0.0)
+			{
+				double rad = Math::deg2rad(_originNormalStepH), c = std::cos(rad), s = std::sin(rad);
+				double nx = _originNormalX, ny = _originNormalY;
+				_originNormalX = nx * c + ny * s;
+				_originNormalY = -nx * s + ny * c;
+			}
+		}
 
 			// OriginAllowCircleTilt：每帧从目标 Z 差更新大圆面倾斜
 			if (Data->OriginAllowCircleTilt && Data->OriginOrigin == VectorData::VectorOrigin::Target)
@@ -840,9 +956,15 @@ VectorResult VectorEffect::GetVectorResult()
 				}
 			}
 
-			double oFacing = _originFacing + Math::deg2rad(_originNormalRotH);
-			double oTilt = _originTilt + Math::deg2rad(_originNormalRotL)
-				+ (Data->OriginAllowOriginTilt ? originTerrainTilt : 0.0);
+			double oFacing = _originFacing;
+			double oTilt = _originTilt + (Data->OriginAllowOriginTilt ? originTerrainTilt : 0.0);
+			// 3D 法向量旋转覆盖
+			if (_originNormalStepF != 0.0 || _originNormalStepL != 0.0 || _originNormalStepH != 0.0)
+			{
+				double lenXY = std::sqrt(_originNormalX * _originNormalX + _originNormalY * _originNormalY);
+				oFacing = lenXY > 1e-6 ? std::atan2(_originNormalY, _originNormalX) : 0.0;
+				oTilt = lenXY > 1e-6 ? std::atan2(_originNormalZ, lenXY) : (_originNormalZ > 0 ? M_PI / 2.0 : -M_PI / 2.0);
+			}
 			DirStruct oFacingDir = Radians2Dir(oFacing); // 官方API，不得修改：弧度→DirStruct
 
 			// 当前圆心绝对位置 = 基座 + 偏移
@@ -997,9 +1119,9 @@ VectorResult VectorEffect::GetVectorResult()
 				double originAngleStep = Data->OriginCircleAnglePerStep;
 				if (Data->OriginCircleSpeed != 0 && tr > 0)
 					originAngleStep = Math::rad2deg(Data->OriginCircleSpeed / tr);
-				// Lissajous=yes: 累积大角旋转（增减边震荡），no: 每帧仅增量旋转（平滑行星）
-				_originCircleAngle += originAngleStep;
-				double r = Data->OriginLissajous ? Math::deg2rad(_originCircleAngle) : Math::deg2rad(originAngleStep);
+			// Lissajous>0: 累积大角旋转（增减边震荡），==0: 每帧仅增量旋转（平滑行星）
+			_originCircleAngle += originAngleStep;
+			double r = Data->OriginLissajous > 0.0 ? Math::deg2rad(_originCircleAngle + _originNormalRotF) : Math::deg2rad(originAngleStep + _originNormalRotF);
 				double ca = std::cos(r), sa = std::sin(r);
 				// 当前圆心相对基座的偏移在 LH 平面投影
 				double dx = (double)_originOffset.X, dy = (double)_originOffset.Y, dz = (double)_originOffset.Z;
@@ -1035,7 +1157,7 @@ VectorResult VectorEffect::GetVectorResult()
 	if (_prevCircleCenter.X || _prevCircleCenter.Y || _prevCircleCenter.Z)
 	{
 		centerDelta = circleCenter - _prevCircleCenter;
-		if (!Data->OriginLissajous && (Data->OriginCircleRadius >= 0 || Data->OriginCircleSpeed != 0 || Data->OriginLinearSpeed >= 0 || Data->OriginCircleAnglePerStep != 0.0))
+		if (Data->OriginLissajous <= 0.0 && (Data->OriginCircleRadius >= 0 || Data->OriginCircleSpeed != 0 || Data->OriginLinearSpeed >= 0 || Data->OriginCircleAnglePerStep != 0.0))
 			useCenterTracking = true;
 	}
 	_prevCircleCenter = circleCenter;
@@ -1086,7 +1208,7 @@ VectorResult VectorEffect::GetVectorResult()
 		if (Data->CircleMinRadius > 0 && targetRadius < Data->CircleMinRadius)
 			targetRadius = static_cast<double>(Data->CircleMinRadius);
 
-		double rad = Math::deg2rad(angleStep);
+		double rad = Math::deg2rad(angleStep + _normalRotF);
 		double cosA = std::cos(rad), sinA = std::sin(rad);
 
 		if (useTiltPlane)
@@ -1233,11 +1355,16 @@ VectorResult VectorEffect::GetVectorResult()
 	{
 	case VectorData::VectorOrigin::Launcher:
 		{
-			TechnoClass* pLT = abstract_cast<TechnoClass*>(_pLauncher);
-			if (pLT)
-				frameTarget = GetFLHAbsoluteCoords(pLT, frameTargetFlh, isOnTurret); // 官方API，不得修改
+			if (Data->OriginNoUpdate)
+				frameTarget = GetFLHAbsoluteCoords(originPos, frameTargetFlh, mainFacingDir); // 锁定原点
 			else
-				frameTarget = GetFLHAbsoluteCoords(originPos, frameTargetFlh, mainFacingDir); // 官方API，不得修改
+			{
+				TechnoClass* pLT = abstract_cast<TechnoClass*>(_pLauncher);
+				if (pLT && !IsDeadOrInvisible(pLT))
+					frameTarget = GetFLHAbsoluteCoords(pLT, frameTargetFlh, isOnTurret); // 官方API，不得修改
+				else
+					frameTarget = GetFLHAbsoluteCoords(originPos, frameTargetFlh, mainFacingDir); // 官方API，不得修改
+			}
 		}
 		break;
 	case VectorData::VectorOrigin::Self:
@@ -1245,6 +1372,8 @@ VectorResult VectorEffect::GetVectorResult()
 		{
 			if (Data->OriginIsOnWorld)
 				frameTarget = GetFLHAbsoluteCoords(originPos, frameTargetFlh, DirStruct{}); // 世界坐标系，无视倾斜
+			else if (Data->OriginNoUpdate)
+				frameTarget = GetFLHAbsoluteCoords(originPos, frameTargetFlh, mainFacingDir); // 锁定原点
 			else
 				frameTarget = GetFLHAbsoluteCoords(pTechno, frameTargetFlh, isOnTurret); // 官方API，不得修改
 		}
@@ -1262,6 +1391,20 @@ VectorResult VectorEffect::GetVectorResult()
 		frameTarget = GetFLHAbsoluteCoords(originPos, frameTargetFlh, mainFacingDir); // 官方API，不得修改
 		break;
 	}
+
+	// === DEBUG: frameTarget (first 5 movement frames) ===
+	if (_movementFrames <= 5)
+	{
+		double mfdRad = mainFacingDir.GetRadian();
+		double mfdDeg = mfdRad * 180.0 / M_PI;
+		Debug::Log("[VectorFrame%d] TargetFLH=(%d,%d,%d) mainFacingDir raw=%-5u r=%.4f deg=%.1f\n",
+			_movementFrames, Data->TargetFLH.X, Data->TargetFLH.Y, Data->TargetFLH.Z,
+			(unsigned)mainFacingDir.Raw, mfdRad, mfdDeg);
+		Debug::Log("  currentPos  = (%d, %d, %d)\n", currentPos.X, currentPos.Y, currentPos.Z);
+		Debug::Log("  originPos   = (%d, %d, %d)\n", originPos.X, originPos.Y, originPos.Z);
+		Debug::Log("  frameTarget = (%d, %d, %d)\n", frameTarget.X, frameTarget.Y, frameTarget.Z);
+	}
+	// === END DEBUG ===
 
 	// --- 方向向量 ---
 	CoordStruct dirVec;

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -894,6 +894,19 @@ VectorResult VectorEffect::GetVectorResult()
 		CoordStruct moveFlh = Data->MoveTo + grow;
 
 		result.MoveDisp = GetFLHAbsoluteOffset(moveFlh, moveDir); // 官方API，不得修改
+		// 坐标轴倾斜：Tilt 非零时覆盖 Z 轴，使 FLH 位移沿倾斜坐标轴方向
+		if (effectiveTilt != 0.0)
+		{
+			double mf = moveDir.GetRadian();
+			double cosF = std::cos(mf), sinF = std::sin(mf);
+			double cosT = std::cos(effectiveTilt), sinT = std::sin(effectiveTilt);
+			double F = static_cast<double>(moveFlh.X);
+			double L = static_cast<double>(moveFlh.Y);
+			double H = static_cast<double>(moveFlh.Z);
+			result.MoveDisp.X = static_cast<int>(F * cosF * cosT + L * (-sinF) + H * (-cosF * sinT));
+			result.MoveDisp.Y = static_cast<int>(F * sinF * cosT + L * cosF + H * (-sinF * sinT));
+			result.MoveDisp.Z = static_cast<int>(F * sinT + H * cosT);
+		}
 		result.Force = true;
 
 		AdvanceFrame();

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -73,6 +73,17 @@ static bool TryGetSpawnManagerTarget(TechnoClass* pTechno, CoordStruct& out)
 	return false;
 }
 
+// 参照 MissileHoming 先例：注册 UnInit 事件，launcher/source 被删除时置空指针防悬垂
+void VectorEffect::Awake()
+{
+	EventSystems::General.AddHandler(Events::ObjectUnInitEvent, this, &VectorEffect::OnTechnoDelete);
+}
+
+void VectorEffect::Destroy()
+{
+	EventSystems::General.RemoveHandler(Events::ObjectUnInitEvent, this, &VectorEffect::OnTechnoDelete);
+}
+
 // 目标缓存（挂在 TechnoStatus，归一目标保护机制）：
 // Techno 获得 Vector 时写入目标单位+格子（Spawn 从 SpawnManager/Kamikaze 取，普通单位记 Target）。
 // NoUpdate=yes 存一次即停，之后只读格子（目标死活不影响）。

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -53,6 +53,12 @@ void VectorEffect::OnStart()
 	if (_arcPeakPercent <= 0.0) _arcPeakPercent = 0.5;
 	if (_arcPeakPercent >= 1.0) _arcPeakPercent = 0.5;
 
+	// 影子坐标（Speed 模式弧高进度基准，不受弧高 Z 偏移污染）
+	_shadowPosX = _initialLocation.X;
+	_shadowPosY = _initialLocation.Y;
+	_shadowPosZ = _initialLocation.Z;
+	_shadowTraveled = 0.0;
+
 	// --- 初始速度 ---
 	_currentSpeed = 0.0;
 	if (Data->LinearSpeed >= 0)
@@ -968,15 +974,17 @@ VectorResult VectorEffect::GetVectorResult()
 		}
 		if (remainingFrames <= 0)
 		{
-			// 已超时
-			if (Data->Force)
+			// 已超时：瞬移到目标，引擎正常到达检测会自然引爆
+			if (Data->Force && pBullet)
 			{
-				// Force=yes：直接到达目标
-				resultDisp.X = frameTarget.X - currentPos.X;
-				resultDisp.Y = frameTarget.Y - currentPos.Y;
-				resultDisp.Z = frameTarget.Z - currentPos.Z;
+				pBullet->SetLocation(frameTarget);
+				result.MoveDisp = { 0, 0, 0 };
+				result.Force = false;
+				Deactivate();
+				AdvanceFrame();
+				return result;
 			}
-			// Force=no：不设位移，自然结束
+			// Force=no 或无 pBullet：不设位移，自然结束
 		}
 		else if (dirLen > 1e-6)
 		{
@@ -1042,7 +1050,9 @@ VectorResult VectorEffect::GetVectorResult()
 	}
 
 	// ========================================================================
-	// 模式5: Speed（直线追踪 + 加速度）
+	// 模式5: Speed（直线追踪 + 加速度 + 影子坐标弧高）
+	// 影子沿 _shadowPos→frameTarget 方向推进，不受弧高Z偏移污染
+	// SpeedEndOnReach 和 t 均基于影子距离判定
 	// ========================================================================
 	if (Data->LinearSpeed >= 0)
 	{
@@ -1060,44 +1070,111 @@ VectorResult VectorEffect::GetVectorResult()
 		if (Data->MaxSpeed >= 0 && speed > Data->MaxSpeed)
 			speed = static_cast<double>(Data->MaxSpeed);
 
-		if (dirLen > 1e-6)
+		// 无弧线：影子仅追踪 XY，Z 独立插值避免增量累积
+		// 有弧线：影子追踪完整 3D，弧高增量叠加
+		double sdx = frameTarget.X - _shadowPosX;
+		double sdy = frameTarget.Y - _shadowPosY;
+		double sdz, shadowDist;
+		if (_arcHeight != 0)
 		{
-			// 抵达目标坐标点即结束AE，钳位到目标点避免飞越后抽搐
-			if (Data->SpeedEndOnReach && dirLen <= speed)
-			{
-				result.MoveDisp = dirVec;
-				Deactivate();
-				AdvanceFrame();
-				return result;
-			}
-			resultDisp.X = static_cast<int>(dirVec.X / dirLen * speed);
-			resultDisp.Y = static_cast<int>(dirVec.Y / dirLen * speed);
-			resultDisp.Z = static_cast<int>(dirVec.Z / dirLen * speed);
+			sdz = frameTarget.Z - _shadowPosZ;
+			shadowDist = std::sqrt(sdx * sdx + sdy * sdy + sdz * sdz);
+		}
+		else
+		{
+			// 无弧线：仅 XY 距离，避免影子 Z 追踪目标导致 shadowDist 虚小
+			sdz = 0.0;
+			shadowDist = std::sqrt(sdx * sdx + sdy * sdy);
+		}
 
-			// 弧高增量叠加（与直线推进解耦，speed 仅代表直线速度）
+		// SpeedEndOnReach：瞬移到目标位置，引擎正常到达检测会自然引爆（不手动Detonate，避免重复伤害）
+		if (Data->SpeedEndOnReach && shadowDist <= speed)
+		{
+			if (pBullet)
+			{
+				pBullet->SetLocation(frameTarget);
+			}
+			// 零位移：位置已由 SetLocation 设定，不再让 Vector.cpp 回退
+			result.MoveDisp = { 0, 0, 0 };
+			result.Force = false;
+			Deactivate();
+			AdvanceFrame();
+			return result;
+		}
+
+		if (shadowDist > 1e-6)
+		{
+			// 影子沿 shadow→target 方向推进
+			double sInv = 1.0 / shadowDist;
+			double shadowStepX = sdx * sInv * speed;
+			double shadowStepY = sdy * sInv * speed;
+			double shadowStepZ = 0.0;
+			_shadowPosX += shadowStepX;
+			_shadowPosY += shadowStepY;
 			if (_arcHeight != 0)
 			{
-				if (_speedArcTotalDist < 0.0)
-					_speedArcTotalDist = dirLen;
-				double t = (_speedArcTotalDist > 1e-6) ? 1.0 - dirLen / _speedArcTotalDist : 0.0;
-				if (t < 0.0) t = 0.0; else if (t > 1.0) t = 1.0;
-				double arcThis = CalcArcOffsetAt(t);
-				double arcDelta = arcThis - _prevArcOffset;
-				_prevArcOffset = arcThis;
+				shadowStepZ = sdz * sInv * speed;
+				_shadowPosZ += shadowStepZ;
+			}
+			// 无弧线：_shadowPosZ 不变（始终 = _initialLocation.Z），Z 由 t 插值
+			_shadowTraveled += speed;
+
+			// 重新计算影子距离（影子已移动）
+			sdx = frameTarget.X - _shadowPosX;
+			sdy = frameTarget.Y - _shadowPosY;
+			if (_arcHeight != 0)
+			{
+				sdz = frameTarget.Z - _shadowPosZ;
+				shadowDist = std::sqrt(sdx * sdx + sdy * sdy + sdz * sdz);
+			}
+			else
+			{
+				shadowDist = std::sqrt(sdx * sdx + sdy * sdy);
+			}
+
+			// t = 已走路程 / 总路程（动态更新，目标移动时自动调整）
+			double total = _shadowTraveled + shadowDist;
+			double t = (total > 1e-6) ? _shadowTraveled / total : 0.0;
+			if (t < 0.0) t = 0.0; else if (t > 1.0) t = 1.0;
+
+			// 实际位移：影子步长（XY）
+			resultDisp.X = static_cast<int>(shadowStepX);
+			resultDisp.Y = static_cast<int>(shadowStepY);
+
+			if (_arcHeight != 0)
+			{
+				// 有弧线：Z 用影子增量 + 弧高增量叠加
+				resultDisp.Z = static_cast<int>(shadowStepZ);
+			}
+			else
+			{
+				// 无弧线：Z 从抛射体起始高度 lerp 到目标高度
+				// _shadowPosZ 在无弧线时冻结为抛射体起始 Z，_initialLocation.Z 可能是目标 Z（Origin=Target 时不同）
+				double targetZ = _shadowPosZ + (frameTarget.Z - _shadowPosZ) * t;
+				resultDisp.Z = static_cast<int>(targetZ - currentPos.Z);
+			}
+
+			if (_arcHeight != 0)
+			{
+				double arcOffset = CalcArcOffsetAt(t);
+				double arcDelta = arcOffset - _prevArcOffset;
+				_prevArcOffset = arcOffset;
 
 				if (_arcRotation == 0.0)
 				{
+					// 无旋转：弧高纯 Z，增量叠加在影子 Z 之上
 					resultDisp.Z += static_cast<int>(arcDelta);
 				}
 				else
 				{
-					double dx = frameTarget.X - _initialLocation.X;
-					double dy = frameTarget.Y - _initialLocation.Y;
-					double dz = frameTarget.Z - _initialLocation.Z;
-					double dLen = std::sqrt(dx * dx + dy * dy + dz * dz);
-					if (dLen > 1e-6)
+					// 旋转弧面：弧高分解到 XYZ（增量叠加，螺旋路径）
+					double totalDx = frameTarget.X - _initialLocation.X;
+					double totalDy = frameTarget.Y - _initialLocation.Y;
+					double totalDz = frameTarget.Z - _initialLocation.Z;
+					double totalDLen = std::sqrt(totalDx * totalDx + totalDy * totalDy + totalDz * totalDz);
+					if (totalDLen > 1e-6)
 					{
-						double dnx = dx / dLen, dny = dy / dLen, dnz = dz / dLen;
+						double dnx = totalDx / totalDLen, dny = totalDy / totalDLen, dnz = totalDz / totalDLen;
 						double upDotD = dnz;
 						double px = -dnx * upDotD, py = -dny * upDotD, pz = 1.0 - dnz * upDotD;
 						double pLen = std::sqrt(px * px + py * py + pz * pz);
@@ -1122,6 +1199,19 @@ VectorResult VectorEffect::GetVectorResult()
 					}
 				}
 			}
+		}
+		else if (!Data->SpeedEndOnReach)
+		{
+			// 影子已到达目标，但 SpeedEndOnReach=no：
+			// 用实时方向继续追踪，保留旧版追着目标抖动的行为
+			// 弧高已在 t=1.0 归零，不再叠加
+			if (dirLen > 1e-6)
+			{
+				resultDisp.X = static_cast<int>(dirVec.X / dirLen * speed);
+				resultDisp.Y = static_cast<int>(dirVec.Y / dirLen * speed);
+				resultDisp.Z = static_cast<int>(dirVec.Z / dirLen * speed);
+			}
+			_prevArcOffset = 0.0;
 		}
 		result.MoveDisp = resultDisp;
 		AdvanceFrame();

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -114,7 +114,7 @@ void VectorEffect::OnStart()
 	}
 
 	// 缓存：只要单位有攻击目标就记录，不限Origin类型，供AE链路后续使用
-	if (pTechno && pTechno->Target)
+	if (pTechno && pTechno->Target && abstract_cast<ObjectClass*>(pTechno->Target) && !IsDeadOrInvisible(abstract_cast<ObjectClass*>(pTechno->Target)))
 		_lastTargetCache[pTechno] = pTechno->Target->GetCoords();
 
 	// --- Origin 初始化 ---
@@ -127,7 +127,7 @@ void VectorEffect::OnStart()
 			if (pTechno)
 			{
 				_initialOriginPos = pTechno->GetCoords();
-				if (pTechno->Target)
+				if (pTechno->Target && abstract_cast<ObjectClass*>(pTechno->Target) && !IsDeadOrInvisible(abstract_cast<ObjectClass*>(pTechno->Target)))
 					_lastTargetCache[pTechno] = pTechno->Target->GetCoords();
 			}
 			else if (pBullet)
@@ -649,6 +649,8 @@ VectorResult VectorEffect::GetVectorResult()
 			double tdy = currentPos.Y - originPos.Y;
 			calcRadius = std::sqrt(tdx * tdx + tdy * tdy);
 		}
+		if (calcRadius < 1.0)
+			calcRadius = 1.0;  // 防止除零：半径 + 角速度互推时必 > 0
 
 		// 动态线速：每帧叠加加速度（初始值已在 DisabledFrames 前预初始化）
 		_currentCircleSpeed += Data->CircleSpeedAcceleration;

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -237,6 +237,8 @@ void VectorEffect::OnStart()
 		{
 			if (AE && AE->pSource)
 				_initialOriginPos = AE->pSource->GetCoords();
+			else
+				_initialOriginPos = pObject->GetCoords(); // 兜底与 Target 分支一致
 		}
 		if (AE && AE->pSource)
 			_pSource = AE->pSource;
@@ -362,14 +364,15 @@ void VectorEffect::OnStart()
 	{
 		if (!hasNormal)
 		{
+			// 与 Target 模式对齐：F 轴 = Origin(Source) → 弹体 方向（每帧 no 路径同向，NoUpdate 切换不再镜像）
 			if (pBullet && AE && AE->pSource)
 			{
-				_facingDir = Point2Dir(pBullet->GetCoords(), AE->pSource->GetCoords()); // 官方API
+				_facingDir = Point2Dir(AE->pSource->GetCoords(), pBullet->GetCoords()); // 官方API
 				_facingRad = _facingDir.GetRadian();
 			}
 			else if (pTechno && AE && AE->pSource)
 			{
-				_facingDir = Point2Dir(pTechno->GetCoords(), AE->pSource->GetCoords()); // 官方API
+				_facingDir = Point2Dir(AE->pSource->GetCoords(), pTechno->GetCoords()); // 官方API
 				_facingRad = _facingDir.GetRadian();
 			}
 		}

--- a/src/Ext/EffectType/Effect/VectorEffect.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffect.cpp
@@ -412,25 +412,22 @@ void VectorEffect::OnStart()
 		break;
 
 	case VectorData::VectorOrigin::Launcher:
-		if (Data->OriginNoUpdate)
-		{
-			if (pBullet && pBullet->Owner)
-				_initialOriginPos = pBullet->Owner->GetCoords();
-			else if (pTechno)
-				_initialOriginPos = pTechno->GetCoords();
-			else
-				_initialOriginPos = pObject->GetCoords();
-		}
+		// 无论 NoUpdate 都锁定基线（与 Target 分支一致）：NoUpdate=yes 直接用，
+		// no 每帧快照刷新覆盖；launcher 死亡时冻结此基线作为 origin 解算起点
+		if (pBullet && pBullet->Owner)
+			_initialOriginPos = pBullet->Owner->GetCoords();
+		else if (pTechno)
+			_initialOriginPos = pTechno->GetCoords();
+		else
+			_initialOriginPos = pObject->GetCoords();
 		break;
 
 	case VectorData::VectorOrigin::Source:
-		if (Data->OriginNoUpdate)
-		{
-			if (AE && AE->pSource)
-				_initialOriginPos = AE->pSource->GetCoords();
-			else
-				_initialOriginPos = pObject->GetCoords(); // 兜底与 Target 分支一致
-		}
+		// 无论 NoUpdate 都锁定基线（与 Target/Launcher 分支一致）：死亡时冻结此基线
+		if (AE && AE->pSource)
+			_initialOriginPos = AE->pSource->GetCoords();
+		else
+			_initialOriginPos = pObject->GetCoords(); // 兜底与 Target 分支一致
 		if (AE && AE->pSource)
 			_pSource = AE->pSource;
 		break;
@@ -990,8 +987,15 @@ VectorResult VectorEffect::GetVectorResult()
 		}
 		break;
 	case VectorData::VectorOrigin::Launcher:
-		originPos = Data->OriginNoUpdate ? _initialOriginPos :
-			(_pLauncher && !IsDeadOrInvisible(_pLauncher) ? _pLauncher->GetCoords() : currentPos);
+		if (Data->OriginNoUpdate)
+			originPos = _initialOriginPos;
+		else if (_pLauncher && !IsDeadOrInvisible(_pLauncher))
+		{
+			_initialOriginPos = _pLauncher->GetCoords(); // 发射者活着：每帧更新快照（与 Source 分支一致）
+			originPos = _initialOriginPos;
+		}
+		else
+			originPos = _initialOriginPos; // 发射者死亡：冻结基线（OnStart 锁定或最后快照），不再读指针
 		break;
 	case VectorData::VectorOrigin::Source:
 		if (Data->OriginNoUpdate)
@@ -1002,7 +1006,7 @@ VectorResult VectorEffect::GetVectorResult()
 			originPos = _initialOriginPos;
 		}
 		else
-			originPos = _initialOriginPos.IsEmpty() ? currentPos : _initialOriginPos; // 来源死亡：冻结死亡坐标
+			originPos = _initialOriginPos; // 来源死亡：冻结基线（OnStart 锁定或最后快照），不再读指针
 		break;
 	case VectorData::VectorOrigin::Self:
 		originPos = Data->OriginNoUpdate ? _initialOriginPos : currentPos;
@@ -1148,27 +1152,66 @@ VectorResult VectorEffect::GetVectorResult()
 				{
 				case VectorData::VectorOrigin::Launcher:
 					if (_pLauncher && !IsDeadOrInvisible(_pLauncher))
+					{
+						if (!Data->OriginOriginNoUpdate)
+							_initialBaseCenter = _pLauncher->GetCoords(); // 发射者活着：每帧快照（NoUpdate=yes 冻结首帧不更新）
 						baseCenter = _pLauncher->GetCoords();
+					}
+					else
+						baseCenter = _initialBaseCenter; // 发射者死亡：冻结快照（首帧或最后跟随值），不再读指针
 					break;
 				case VectorData::VectorOrigin::Target:
-					if (pTechno && pTechno->Target)
-						baseCenter = pTechno->Target->GetCoords();
-					else if (pTechno)
 					{
-						FootClass* pFoot = abstract_cast<FootClass*>(pTechno);
-						if (pFoot && pFoot->Destination)
-							baseCenter = pFoot->Destination->GetCoords();
+						CoordStruct targetBase{};
+						bool gotTargetBase = false;
+						if (pTechno && pTechno->Target)
+						{
+							targetBase = pTechno->Target->GetCoords();
+							gotTargetBase = true;
+						}
+						else if (pTechno)
+						{
+							FootClass* pFoot = abstract_cast<FootClass*>(pTechno);
+							if (pFoot && pFoot->Destination)
+							{
+								targetBase = pFoot->Destination->GetCoords();
+								gotTargetBase = true;
+							}
+						}
+						else if (pBullet && pBullet->Target)
+						{
+							targetBase = pBullet->Target->GetCoords();
+							gotTargetBase = true;
+						}
+						else if (pBullet && pBullet->Owner && pBullet->Owner->Target)
+						{
+							targetBase = pBullet->Owner->Target->GetCoords();
+							gotTargetBase = true;
+						}
+						else if (pBullet)
+						{
+							targetBase = pBullet->TargetCoords;
+							gotTargetBase = true;
+						}
+						if (gotTargetBase)
+						{
+							if (!Data->OriginOriginNoUpdate)
+								_initialBaseCenter = targetBase; // 目标活着：每帧快照（NoUpdate=yes 冻结首帧不更新）
+							baseCenter = targetBase;
+						}
+						else
+							baseCenter = _initialBaseCenter; // 目标失效：冻结快照（首帧或最后跟随值），不再掉回 originPos
 					}
-					else if (pBullet && pBullet->Target)
-						baseCenter = pBullet->Target->GetCoords();
-					else if (pBullet && pBullet->Owner && pBullet->Owner->Target)
-						baseCenter = pBullet->Owner->Target->GetCoords();
-					else if (pBullet)
-						baseCenter = pBullet->TargetCoords;
 					break;
 				case VectorData::VectorOrigin::Source:
 					if (_pSource && !IsDeadOrInvisible(_pSource))
+					{
+						if (!Data->OriginOriginNoUpdate)
+							_initialBaseCenter = _pSource->GetCoords(); // 来源活着：每帧快照（NoUpdate=yes 冻结首帧不更新）
 						baseCenter = _pSource->GetCoords();
+					}
+					else
+						baseCenter = _initialBaseCenter; // 来源死亡：冻结快照（首帧或最后跟随值），不再读指针
 					break;
 				}
 			}

--- a/src/Ext/EffectType/Effect/VectorEffect.h
+++ b/src/Ext/EffectType/Effect/VectorEffect.h
@@ -14,6 +14,18 @@ class VectorEffect : public EffectScript
 public:
 	EFFECT_SCRIPT(Vector);
 
+	virtual void Awake() override;
+	virtual void Destroy() override;
+
+	// 参照 MissileHoming 先例：目标单位 UnInit 时清空指针，防止悬垂
+	void OnTechnoDelete(EventSystem* sender, Event e, void* args)
+	{
+		if (args == _pLauncher)
+			_pLauncher = nullptr;
+		if (args == _pSource)
+			_pSource = nullptr;
+	}
+
 	virtual void Clean() override
 	{
 		EffectScript::Clean();

--- a/src/Ext/EffectType/Effect/VectorEffect.h
+++ b/src/Ext/EffectType/Effect/VectorEffect.h
@@ -68,6 +68,7 @@ public:
 		_originLissajousStep = 0.0;
 		_originTargetOffset = {};
 		_prevCircleCenter = {};
+		_circlePos = {};
 		_movementFrames = 0;
 		_arcRotation = 0.0;
 		_arcHeight = 0;
@@ -174,6 +175,7 @@ public:
 			.Process(this->_originLissajousStep)
 			.Process(this->_originTargetOffset)
 			.Process(this->_prevCircleCenter)
+			.Process(this->_circlePos)
 			.Process(this->_movementFrames)
 			.Process(this->_arcRotation)
 			.Process(this->_arcHeight)
@@ -250,6 +252,7 @@ public:
 	double _originLissajousStep = 0.0;
 	CoordStruct _originTargetOffset{};    // 圆心 Target 随机偏移
 	CoordStruct _prevCircleCenter{};      // 上一帧圆心位置（计算叠加位移用）
+	CoordStruct _circlePos{};            // 圆上内部跟踪位置（增量位移，不打架 MoveTo）
 	int _movementFrames = 0;              // 有效运动帧数（不含 InitialDelay/TimeStep 跳帧）
 	double _arcRotation = 0.0;           // 弧面旋转角（OnStart 解析，ReachTarget / Speed）
 	int _arcHeight = 0;                 // 弧高（OnStart 解析随机后写入，ReachTarget / Speed）

--- a/src/Ext/EffectType/Effect/VectorEffect.h
+++ b/src/Ext/EffectType/Effect/VectorEffect.h
@@ -2,7 +2,6 @@
 
 #include <string>
 #include <vector>
-#include <map>
 
 #include <GeneralDefinitions.h>
 
@@ -17,16 +16,6 @@ public:
 	virtual void Clean() override
 	{
 		EffectScript::Clean();
-
-		// 清理静态缓存中的死条目（先收集后擦除，避免多实例并发迭代同一 map）
-		std::vector<TechnoClass*> deadKeys;
-		for (auto& pair : _lastTargetCache)
-		{
-			if (IsDeadOrInvisible(pair.first))
-				deadKeys.push_back(pair.first);
-		}
-		for (auto* key : deadKeys)
-			_lastTargetCache.erase(key);
 
 		_elapsedFrames = 0;
 		_moveFrame = 0;
@@ -88,10 +77,6 @@ public:
 		_initialBaseCenter = {};
 		_vectorAcquireZ = 0;
 	}
-
-	// 跨 AE 链路目标坐标缓存：只要单位有攻击目标就记录，
-	// AE 链条中断后新 AE 的 OriginNoUpdate 仍可回退到上一 AE 记录的坐标
-	static std::map<TechnoClass*, CoordStruct> _lastTargetCache;
 
 	virtual void OnStart() override;
 

--- a/src/Ext/EffectType/Effect/VectorEffect.h
+++ b/src/Ext/EffectType/Effect/VectorEffect.h
@@ -263,6 +263,6 @@ public:
 	double _originArcPeakPercent = 0.5; // Origin 弧高点比率 0..1
 	double _originArcRotation = 0.0;   // Origin 弧面旋转角（OnStart 解析）
 	CoordStruct _originArcStartCenter{}; // Origin 弧线起始圆心位置
-	CoordStruct _initialBaseCenter{};   // Origin 基座初始快照（OriginNoUpdate 用）
+	CoordStruct _initialBaseCenter{};   // Origin 基座初始快照（Origin.OriginNoUpdate 用）
 	int _vectorAcquireZ = 0;            // 获取 Vector 时的抛射体 Z（Circle 圆心高度基准）
 };

--- a/src/Ext/EffectType/Effect/VectorEffect.h
+++ b/src/Ext/EffectType/Effect/VectorEffect.h
@@ -14,10 +14,6 @@ class VectorEffect : public EffectScript
 public:
 	EFFECT_SCRIPT(Vector);
 
-	// 目标坐标缓存（跨 AE 实例，6 月版机制恢复）：SpawnMissile 未统一设 Target 前的过渡期，
-	// 以及单位目标死亡后，用缓存的上一帧有效目标坐标继续指向
-	static std::map<TechnoClass*, CoordStruct> _lastTargetCache;
-
 	virtual void Clean() override
 	{
 		EffectScript::Clean();
@@ -84,6 +80,11 @@ public:
 	}
 
 	virtual void OnStart() override;
+
+	// 记录/刷新目标缓存（挂在 TechnoStatus 上，归一目标保护机制）：
+	// Techno 获得 Vector 时写入目标单位+格子（Spawn 从 SpawnManager/Kamikaze 取，普通单位记 Target）。
+	// NoUpdate=yes 存一次即停，之后只读格子（目标死活不影响）；no 每帧刷新，目标死亡/无效（脚下格子）冻结最后有效值
+	void CacheTargetNow();
 
 	VectorResult GetVectorResult();
 

--- a/src/Ext/EffectType/Effect/VectorEffect.h
+++ b/src/Ext/EffectType/Effect/VectorEffect.h
@@ -33,6 +33,7 @@ public:
 		_effectiveTimeStep = 1;
 		_initialLocation = {};
 		_initialOriginPos = {};
+		_arcStartLocation = {};
 		_pLauncher = nullptr;
 		_pSource = nullptr;
 		_totalDuration = 0;
@@ -138,6 +139,7 @@ public:
 			.Process(this->_effectiveTimeStep)
 			.Process(this->_initialLocation)
 			.Process(this->_initialOriginPos)
+			.Process(this->_arcStartLocation)
 			.Process(this->_pLauncher)
 			.Process(this->_pSource)
 			.Process(this->_totalDuration)
@@ -211,6 +213,7 @@ public:
 
 	CoordStruct _initialLocation{};     // 初始位置快照
 	CoordStruct _initialOriginPos{};    // 初始 Origin 快照（NoUpdate 用）
+	CoordStruct _arcStartLocation{};   // 弧线起点快照（DisFrames结束后抓取）
 	ObjectClass* _pLauncher = nullptr;
 	ObjectClass* _pSource = nullptr;
 

--- a/src/Ext/EffectType/Effect/VectorEffect.h
+++ b/src/Ext/EffectType/Effect/VectorEffect.h
@@ -70,6 +70,7 @@ public:
 	_prevArcOffset = 0.0;
 		_originArcTotalDist = -1.0;
 		_originPrevArcOffset = 0.0;
+		_vectorAcquireZ = 0;
 	}
 
 	virtual void OnStart() override;
@@ -163,7 +164,8 @@ public:
 		.Process(this->_shadowTraveled)
 		.Process(this->_prevArcOffset)
 			.Process(this->_originArcTotalDist)
-			.Process(this->_originPrevArcOffset);
+			.Process(this->_originPrevArcOffset)
+			.Process(this->_vectorAcquireZ);
 		return stream.Success();
 	};
 
@@ -237,4 +239,5 @@ public:
 	// Speed 模式弧高增量计算（Origin 圆心）
 	double _originArcTotalDist = -1.0;  // Origin 首帧初始总距离（<0=未初始化）
 	double _originPrevArcOffset = 0.0;  // Origin 上一帧弧高绝对值
+	int _vectorAcquireZ = 0;            // 获取 Vector 时的抛射体 Z（Circle 圆心高度基准）
 };

--- a/src/Ext/EffectType/Effect/VectorEffect.h
+++ b/src/Ext/EffectType/Effect/VectorEffect.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -12,6 +13,10 @@ class VectorEffect : public EffectScript
 {
 public:
 	EFFECT_SCRIPT(Vector);
+
+	// 目标坐标缓存（跨 AE 实例，6 月版机制恢复）：SpawnMissile 未统一设 Target 前的过渡期，
+	// 以及单位目标死亡后，用缓存的上一帧有效目标坐标继续指向
+	static std::map<TechnoClass*, CoordStruct> _lastTargetCache;
 
 	virtual void Clean() override
 	{

--- a/src/Ext/EffectType/Effect/VectorEffect.h
+++ b/src/Ext/EffectType/Effect/VectorEffect.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <vector>
+#include <map>
 
 #include <GeneralDefinitions.h>
 
@@ -17,7 +18,15 @@ public:
 	{
 		EffectScript::Clean();
 
-		_active = false;
+		// 清理静态缓存中的死条目，防止悬空指针
+		for (auto it = _lastTargetCache.begin(); it != _lastTargetCache.end();)
+		{
+			if (IsDeadOrInvisible(it->first))
+				it = _lastTargetCache.erase(it);
+			else
+				++it;
+		}
+
 		_elapsedFrames = 0;
 		_moveFrame = 0;
 		_currentSpeed = 0.0;
@@ -25,23 +34,22 @@ public:
 		_initialLocation = {};
 		_initialOriginPos = {};
 		_pLauncher = nullptr;
-		// _pTarget = nullptr;  // [DEAD]
 		_pSource = nullptr;
 		_totalDuration = 0;
 		_randomTargetOffset = {};
 		_facingRad = 0.0;
+		_facingDir = DirStruct(0);
 		_currentAngle = 0.0;
 		_tiltRad = 0.0;                  // F 轴俯仰角（AllowedTilt 用）
-		// _prevCirclePos = {};  // [DEAD]
 		_currentCircleRadius = 0.0;
 		_currentCircleSpeed = 0.0;
 		_currentCircleAngle = 0.0;
 		_normalRotF = 0.0;
-		_normalRotL = 0.0;
-		_normalRotH = 0.0;
 		_normalStepF = 0.0;
 		_normalStepL = 0.0;
 		_normalStepH = 0.0;
+		_normalX = 0.0; _normalY = 0.0; _normalZ = 1.0;
+		_lissajousStep = 0.0;
 		_originOffset = {};
 		_originElapsed = 0;
 		_originSpeed = 0.0;
@@ -52,11 +60,11 @@ public:
 		_originFacing = 0.0;
 		_originTilt = 0.0;
 		_originNormalRotF = 0.0;
-		_originNormalRotL = 0.0;
-		_originNormalRotH = 0.0;
 		_originNormalStepF = 0.0;
 		_originNormalStepL = 0.0;
 		_originNormalStepH = 0.0;
+		_originNormalX = 0.0; _originNormalY = 0.0; _originNormalZ = 1.0;
+		_originLissajousStep = 0.0;
 		_originTargetOffset = {};
 		_prevCircleCenter = {};
 		_movementFrames = 0;
@@ -76,6 +84,10 @@ public:
 		_originArcStartCenter = {};
 		_vectorAcquireZ = 0;
 	}
+
+	// 跨 AE 链路目标坐标缓存：只要单位有攻击目标就记录，
+	// AE 链条中断后新 AE 的 OriginNoUpdate 仍可回退到上一 AE 记录的坐标
+	static std::map<TechnoClass*, CoordStruct> _lastTargetCache;
 
 	virtual void OnStart() override;
 
@@ -120,7 +132,6 @@ public:
 	template <typename T>
 	bool Serialize(T& stream) {
 		stream
-			.Process(this->_active)
 			.Process(this->_elapsedFrames)
 			.Process(this->_moveFrame)
 			.Process(this->_currentSpeed)
@@ -128,23 +139,22 @@ public:
 			.Process(this->_initialLocation)
 			.Process(this->_initialOriginPos)
 			.Process(this->_pLauncher)
-			// .Process(this->_pTarget)  // [DEAD] 已注释
 			.Process(this->_pSource)
 			.Process(this->_totalDuration)
 			.Process(this->_randomTargetOffset)
 			.Process(this->_facingRad)
+			.Process(this->_facingDir)
 			.Process(this->_tiltRad)
 			.Process(this->_currentAngle)
-			// .Process(this->_prevCirclePos)  // [DEAD] 已注释
 			.Process(this->_currentCircleRadius)
 			.Process(this->_currentCircleSpeed)
 			.Process(this->_currentCircleAngle)
 			.Process(this->_normalRotF)
-			.Process(this->_normalRotL)
-			.Process(this->_normalRotH)
 			.Process(this->_normalStepF)
 			.Process(this->_normalStepL)
 			.Process(this->_normalStepH)
+			.Process(this->_normalX).Process(this->_normalY).Process(this->_normalZ)
+			.Process(this->_lissajousStep)
 			.Process(this->_originOffset)
 			.Process(this->_originElapsed)
 			.Process(this->_originSpeed)
@@ -155,11 +165,11 @@ public:
 			.Process(this->_originFacing)
 			.Process(this->_originTilt)
 			.Process(this->_originNormalRotF)
-			.Process(this->_originNormalRotL)
-			.Process(this->_originNormalRotH)
 			.Process(this->_originNormalStepF)
 			.Process(this->_originNormalStepL)
 			.Process(this->_originNormalStepH)
+			.Process(this->_originNormalX).Process(this->_originNormalY).Process(this->_originNormalZ)
+			.Process(this->_originLissajousStep)
 			.Process(this->_originTargetOffset)
 			.Process(this->_prevCircleCenter)
 			.Process(this->_movementFrames)
@@ -194,7 +204,6 @@ public:
 	}
 #pragma endregion
 
-	bool _active = false;
 	int _elapsedFrames = 0;             // 已执行运动帧数
 	int _moveFrame = 0;                 // 真实帧计数
 	double _currentSpeed = 0.0;         // 当前速度
@@ -203,24 +212,23 @@ public:
 	CoordStruct _initialLocation{};     // 初始位置快照
 	CoordStruct _initialOriginPos{};    // 初始 Origin 快照（NoUpdate 用）
 	ObjectClass* _pLauncher = nullptr;
-	// ObjectClass* _pTarget = nullptr;  // [DEAD] 从未赋值也从未读取
 	ObjectClass* _pSource = nullptr;
 
 	int _totalDuration = 0;             // AE 总持续时间（ReachTarget 用）
 	CoordStruct _randomTargetOffset{};  // 随机偏移
 	double _facingRad = 0.0;           // OnStart 时锁定的朝向弧度（FLH 旋转用）
+	DirStruct _facingDir;               // OnStart 时锁定的朝向（Point2Dir 结果，Target/Source）
 	double _tiltRad = 0.0;             // F 轴俯仰角（AllowedTilt 用）
 	double _currentAngle = 0.0;        // MoveTo 模式自增角度（°）
-	// CoordStruct _prevCirclePos{};      // [DEAD] MoveTo 圆周模式上一帧世界坐标 — 从未读取
 	double _currentCircleRadius = 0.0; // Circle 模式动态半径
 	double _currentCircleSpeed = 0.0;  // Circle 模式动态线速度
 	double _currentCircleAngle = 0.0;  // Circle 模式动态角速度
-	double _normalRotF = 0.0;          // 法线绕 F 轴累计旋转（°）
-	double _normalRotL = 0.0;          // 法线绕 L 轴累计旋转（°）
-	double _normalRotH = 0.0;          // 法线绕 H 轴累计旋转（°）
+	double _normalRotF = 0.0;          // 法线绕 F 轴累计旋转（°），Lissajous 累加用
 	double _normalStepF = 0.0;         // 法线每步角速度（已解析）
 	double _normalStepL = 0.0;
 	double _normalStepH = 0.0;
+	double _normalX = 0.0, _normalY = 0.0, _normalZ = 1.0;  // 3D 法向量（世界 X/Y/Z），增量旋转维护
+	double _lissajousStep = 0.0;         // Lissajous 圆周 F 偏移每步角度
 	// Origin 圆心运动状态
 	CoordStruct _originOffset{};            // 圆心相对基座偏移（首帧 0）
 	int _originElapsed = 0;               // 圆心已执行运动帧数
@@ -231,12 +239,12 @@ public:
 	double _originCircleAngle = 0.0;      // 圆心 Circle 动态角速度
 	double _originFacing = 0.0;           // 圆心有效 facing
 	double _originTilt = 0.0;             // 圆心有效 tilt
-	double _originNormalRotF = 0.0;       // 圆心法线旋转累计
-	double _originNormalRotL = 0.0;
-	double _originNormalRotH = 0.0;
+	double _originNormalRotF = 0.0;       // 圆心法线旋转累计（Lissajous 累加用）
 	double _originNormalStepF = 0.0;      // 圆心法线每步角速度
 	double _originNormalStepL = 0.0;
 	double _originNormalStepH = 0.0;
+	double _originNormalX = 0.0, _originNormalY = 0.0, _originNormalZ = 1.0;
+	double _originLissajousStep = 0.0;
 	CoordStruct _originTargetOffset{};    // 圆心 Target 随机偏移
 	CoordStruct _prevCircleCenter{};      // 上一帧圆心位置（计算叠加位移用）
 	int _movementFrames = 0;              // 有效运动帧数（不含 InitialDelay/TimeStep 跳帧）

--- a/src/Ext/EffectType/Effect/VectorEffect.h
+++ b/src/Ext/EffectType/Effect/VectorEffect.h
@@ -63,8 +63,11 @@ public:
 		_arcRotation = 0.0;
 		_arcHeight = 0;
 		_arcPeakPercent = 0.5;
-		_speedArcTotalDist = -1.0;
-		_prevArcOffset = 0.0;
+	_shadowPosX = 0.0;
+	_shadowPosY = 0.0;
+	_shadowPosZ = 0.0;
+	_shadowTraveled = 0.0;
+	_prevArcOffset = 0.0;
 		_originArcTotalDist = -1.0;
 		_originPrevArcOffset = 0.0;
 	}
@@ -154,8 +157,11 @@ public:
 			.Process(this->_arcRotation)
 			.Process(this->_arcHeight)
 			.Process(this->_arcPeakPercent)
-			.Process(this->_speedArcTotalDist)
-			.Process(this->_prevArcOffset)
+		.Process(this->_shadowPosX)
+		.Process(this->_shadowPosY)
+		.Process(this->_shadowPosZ)
+		.Process(this->_shadowTraveled)
+		.Process(this->_prevArcOffset)
 			.Process(this->_originArcTotalDist)
 			.Process(this->_originPrevArcOffset);
 		return stream.Success();
@@ -222,8 +228,11 @@ public:
 	double _arcRotation = 0.0;           // 弧面旋转角（OnStart 解析，ReachTarget / Speed）
 	int _arcHeight = 0;                 // 弧高（OnStart 解析随机后写入，ReachTarget / Speed）
 	double _arcPeakPercent = 0.5;        // 弧高点比率 0..1（OnStart 解析随机后写入）
-	// Speed 模式弧高增量计算（主抛射体）
-	double _speedArcTotalDist = -1.0;   // 首帧初始总距离（<0=未初始化）
+	// Speed 模式影子坐标（三维，不受弧高污染，用于计算干净进度 t）
+	double _shadowPosX = 0.0;
+	double _shadowPosY = 0.0;
+	double _shadowPosZ = 0.0;
+	double _shadowTraveled = 0.0;        // 影子累计行走距离（含加速度/变速）
 	double _prevArcOffset = 0.0;        // 上一帧弧高绝对值
 	// Speed 模式弧高增量计算（Origin 圆心）
 	double _originArcTotalDist = -1.0;  // Origin 首帧初始总距离（<0=未初始化）

--- a/src/Ext/EffectType/Effect/VectorEffect.h
+++ b/src/Ext/EffectType/Effect/VectorEffect.h
@@ -25,17 +25,48 @@ public:
 		_initialLocation = {};
 		_initialOriginPos = {};
 		_pLauncher = nullptr;
-		_pTarget = nullptr;
+		// _pTarget = nullptr;  // [DEAD]
 		_pSource = nullptr;
 		_totalDuration = 0;
 		_randomTargetOffset = {};
 		_facingRad = 0.0;
 		_currentAngle = 0.0;
 		_tiltRad = 0.0;                  // F 轴俯仰角（AllowedTilt 用）
-		_prevCirclePos = {};
+		// _prevCirclePos = {};  // [DEAD]
 		_currentCircleRadius = 0.0;
 		_currentCircleSpeed = 0.0;
 		_currentCircleAngle = 0.0;
+		_normalRotF = 0.0;
+		_normalRotL = 0.0;
+		_normalRotH = 0.0;
+		_normalStepF = 0.0;
+		_normalStepL = 0.0;
+		_normalStepH = 0.0;
+		_originOffset = {};
+		_originElapsed = 0;
+		_originSpeed = 0.0;
+		_originAngle = 0.0;
+		_originCircleRadius = 0.0;
+		_originCircleSpeed = 0.0;
+		_originCircleAngle = 0.0;
+		_originFacing = 0.0;
+		_originTilt = 0.0;
+		_originNormalRotF = 0.0;
+		_originNormalRotL = 0.0;
+		_originNormalRotH = 0.0;
+		_originNormalStepF = 0.0;
+		_originNormalStepL = 0.0;
+		_originNormalStepH = 0.0;
+		_originTargetOffset = {};
+		_prevCircleCenter = {};
+		_movementFrames = 0;
+		_arcRotation = 0.0;
+		_arcHeight = 0;
+		_arcPeakPercent = 0.5;
+		_speedArcTotalDist = -1.0;
+		_prevArcOffset = 0.0;
+		_originArcTotalDist = -1.0;
+		_originPrevArcOffset = 0.0;
 	}
 
 	virtual void OnStart() override;
@@ -57,6 +88,22 @@ public:
 		_moveFrame++;
 	}
 
+	// 弧高二次曲线（ReachTarget / Speed 共用），t∈[0,1] 返回弧高绝对值
+	double CalcArcOffsetAt(double t) const
+	{
+		if (_arcHeight == 0) return 0.0;
+		if (t <= _arcPeakPercent)
+		{
+			double u = t / _arcPeakPercent;
+			return _arcHeight * u * (2.0 - u);
+		}
+		else
+		{
+			double u = (_arcPeakPercent < 1.0) ? (t - _arcPeakPercent) / (1.0 - _arcPeakPercent) : 0.0;
+			return _arcHeight * (1.0 - u * u);
+		}
+	}
+
 #pragma region Save/Load
 	template <typename T>
 	bool Serialize(T& stream) {
@@ -69,17 +116,48 @@ public:
 			.Process(this->_initialLocation)
 			.Process(this->_initialOriginPos)
 			.Process(this->_pLauncher)
-			.Process(this->_pTarget)
+			// .Process(this->_pTarget)  // [DEAD] 已注释
 			.Process(this->_pSource)
 			.Process(this->_totalDuration)
 			.Process(this->_randomTargetOffset)
 			.Process(this->_facingRad)
 			.Process(this->_tiltRad)
 			.Process(this->_currentAngle)
-			.Process(this->_prevCirclePos)
+			// .Process(this->_prevCirclePos)  // [DEAD] 已注释
 			.Process(this->_currentCircleRadius)
 			.Process(this->_currentCircleSpeed)
-			.Process(this->_currentCircleAngle);
+			.Process(this->_currentCircleAngle)
+			.Process(this->_normalRotF)
+			.Process(this->_normalRotL)
+			.Process(this->_normalRotH)
+			.Process(this->_normalStepF)
+			.Process(this->_normalStepL)
+			.Process(this->_normalStepH)
+			.Process(this->_originOffset)
+			.Process(this->_originElapsed)
+			.Process(this->_originSpeed)
+			.Process(this->_originAngle)
+			.Process(this->_originCircleRadius)
+			.Process(this->_originCircleSpeed)
+			.Process(this->_originCircleAngle)
+			.Process(this->_originFacing)
+			.Process(this->_originTilt)
+			.Process(this->_originNormalRotF)
+			.Process(this->_originNormalRotL)
+			.Process(this->_originNormalRotH)
+			.Process(this->_originNormalStepF)
+			.Process(this->_originNormalStepL)
+			.Process(this->_originNormalStepH)
+			.Process(this->_originTargetOffset)
+			.Process(this->_prevCircleCenter)
+			.Process(this->_movementFrames)
+			.Process(this->_arcRotation)
+			.Process(this->_arcHeight)
+			.Process(this->_arcPeakPercent)
+			.Process(this->_speedArcTotalDist)
+			.Process(this->_prevArcOffset)
+			.Process(this->_originArcTotalDist)
+			.Process(this->_originPrevArcOffset);
 		return stream.Success();
 	};
 
@@ -104,7 +182,7 @@ public:
 	CoordStruct _initialLocation{};     // 初始位置快照
 	CoordStruct _initialOriginPos{};    // 初始 Origin 快照（NoUpdate 用）
 	ObjectClass* _pLauncher = nullptr;
-	ObjectClass* _pTarget = nullptr;
+	// ObjectClass* _pTarget = nullptr;  // [DEAD] 从未赋值也从未读取
 	ObjectClass* _pSource = nullptr;
 
 	int _totalDuration = 0;             // AE 总持续时间（ReachTarget 用）
@@ -112,7 +190,7 @@ public:
 	double _facingRad = 0.0;           // OnStart 时锁定的朝向弧度（FLH 旋转用）
 	double _tiltRad = 0.0;             // F 轴俯仰角（AllowedTilt 用）
 	double _currentAngle = 0.0;        // MoveTo 模式自增角度（°）
-	CoordStruct _prevCirclePos{};      // MoveTo 圆周模式上一帧世界坐标
+	// CoordStruct _prevCirclePos{};      // [DEAD] MoveTo 圆周模式上一帧世界坐标 — 从未读取
 	double _currentCircleRadius = 0.0; // Circle 模式动态半径
 	double _currentCircleSpeed = 0.0;  // Circle 模式动态线速度
 	double _currentCircleAngle = 0.0;  // Circle 模式动态角速度
@@ -141,6 +219,13 @@ public:
 	CoordStruct _originTargetOffset{};    // 圆心 Target 随机偏移
 	CoordStruct _prevCircleCenter{};      // 上一帧圆心位置（计算叠加位移用）
 	int _movementFrames = 0;              // 有效运动帧数（不含 InitialDelay/TimeStep 跳帧）
-	double _arcRotation = 0.0;           // 弧面旋转角（OnStart 解析，仅 ReachTarget）
-	int _arcHeight = 0;                 // 弧高（OnStart 解析随机后写入）
+	double _arcRotation = 0.0;           // 弧面旋转角（OnStart 解析，ReachTarget / Speed）
+	int _arcHeight = 0;                 // 弧高（OnStart 解析随机后写入，ReachTarget / Speed）
+	double _arcPeakPercent = 0.5;        // 弧高点比率 0..1（OnStart 解析随机后写入）
+	// Speed 模式弧高增量计算（主抛射体）
+	double _speedArcTotalDist = -1.0;   // 首帧初始总距离（<0=未初始化）
+	double _prevArcOffset = 0.0;        // 上一帧弧高绝对值
+	// Speed 模式弧高增量计算（Origin 圆心）
+	double _originArcTotalDist = -1.0;  // Origin 首帧初始总距离（<0=未初始化）
+	double _originPrevArcOffset = 0.0;  // Origin 上一帧弧高绝对值
 };

--- a/src/Ext/EffectType/Effect/VectorEffect.h
+++ b/src/Ext/EffectType/Effect/VectorEffect.h
@@ -18,14 +18,15 @@ public:
 	{
 		EffectScript::Clean();
 
-		// 清理静态缓存中的死条目，防止悬空指针
-		for (auto it = _lastTargetCache.begin(); it != _lastTargetCache.end();)
+		// 清理静态缓存中的死条目（先收集后擦除，避免多实例并发迭代同一 map）
+		std::vector<TechnoClass*> deadKeys;
+		for (auto& pair : _lastTargetCache)
 		{
-			if (IsDeadOrInvisible(it->first))
-				it = _lastTargetCache.erase(it);
-			else
-				++it;
+			if (IsDeadOrInvisible(pair.first))
+				deadKeys.push_back(pair.first);
 		}
+		for (auto* key : deadKeys)
+			_lastTargetCache.erase(key);
 
 		_elapsedFrames = 0;
 		_moveFrame = 0;
@@ -73,17 +74,18 @@ public:
 		_arcRotation = 0.0;
 		_arcHeight = 0;
 		_arcPeakPercent = 0.5;
-	_shadowPosX = 0.0;
-	_shadowPosY = 0.0;
-	_shadowPosZ = 0.0;
-	_shadowTraveled = 0.0;
-	_prevArcOffset = 0.0;
+		_shadowPosX = 0.0;
+		_shadowPosY = 0.0;
+		_shadowPosZ = 0.0;
+		_shadowTraveled = 0.0;
+		_prevArcOffset = 0.0;
 		_originArcTotalDist = -1.0;
 		_originPrevArcOffset = 0.0;
 		_originArcHeight = 0;
 		_originArcPeakPercent = 0.5;
 		_originArcRotation = 0.0;
 		_originArcStartCenter = {};
+		_initialBaseCenter = {};
 		_vectorAcquireZ = 0;
 	}
 

--- a/src/Ext/EffectType/Effect/VectorEffect.h
+++ b/src/Ext/EffectType/Effect/VectorEffect.h
@@ -70,6 +70,10 @@ public:
 	_prevArcOffset = 0.0;
 		_originArcTotalDist = -1.0;
 		_originPrevArcOffset = 0.0;
+		_originArcHeight = 0;
+		_originArcPeakPercent = 0.5;
+		_originArcRotation = 0.0;
+		_originArcStartCenter = {};
 		_vectorAcquireZ = 0;
 	}
 
@@ -93,19 +97,23 @@ public:
 	}
 
 	// 弧高二次曲线（ReachTarget / Speed 共用），t∈[0,1] 返回弧高绝对值
-	double CalcArcOffsetAt(double t) const
+	static double CalcArcOffsetAt(int height, double peakPercent, double t)
 	{
-		if (_arcHeight == 0) return 0.0;
-		if (t <= _arcPeakPercent)
+		if (height == 0) return 0.0;
+		if (t <= peakPercent)
 		{
-			double u = t / _arcPeakPercent;
-			return _arcHeight * u * (2.0 - u);
+			double u = t / peakPercent;
+			return height * u * (2.0 - u);
 		}
 		else
 		{
-			double u = (_arcPeakPercent < 1.0) ? (t - _arcPeakPercent) / (1.0 - _arcPeakPercent) : 0.0;
-			return _arcHeight * (1.0 - u * u);
+			double u = (peakPercent < 1.0) ? (t - peakPercent) / (1.0 - peakPercent) : 0.0;
+			return height * (1.0 - u * u);
 		}
+	}
+	double CalcArcOffsetAt(double t) const
+	{
+		return CalcArcOffsetAt(_arcHeight, _arcPeakPercent, t);
 	}
 
 #pragma region Save/Load
@@ -165,6 +173,11 @@ public:
 		.Process(this->_prevArcOffset)
 			.Process(this->_originArcTotalDist)
 			.Process(this->_originPrevArcOffset)
+			.Process(this->_originArcHeight)
+			.Process(this->_originArcPeakPercent)
+			.Process(this->_originArcRotation)
+			.Process(this->_originArcStartCenter)
+			.Process(this->_initialBaseCenter)
 			.Process(this->_vectorAcquireZ);
 		return stream.Success();
 	};
@@ -239,5 +252,10 @@ public:
 	// Speed 模式弧高增量计算（Origin 圆心）
 	double _originArcTotalDist = -1.0;  // Origin 首帧初始总距离（<0=未初始化）
 	double _originPrevArcOffset = 0.0;  // Origin 上一帧弧高绝对值
+	int _originArcHeight = 0;          // Origin 弧高（OnStart 解析随机后写入）
+	double _originArcPeakPercent = 0.5; // Origin 弧高点比率 0..1
+	double _originArcRotation = 0.0;   // Origin 弧面旋转角（OnStart 解析）
+	CoordStruct _originArcStartCenter{}; // Origin 弧线起始圆心位置
+	CoordStruct _initialBaseCenter{};   // Origin 基座初始快照（OriginNoUpdate 用）
 	int _vectorAcquireZ = 0;            // 获取 Vector 时的抛射体 Z（Circle 圆心高度基准）
 };

--- a/src/Ext/EffectType/Effect/VectorEffectReVibed.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffectReVibed.cpp
@@ -1,0 +1,2099 @@
+#include "VectorEffectReVibed.h"
+
+#include <Utilities/Debug.h>
+
+#include <Kamikaze.h>
+#include <SpawnManagerClass.h>
+#include <RocketLocomotionClass.h>
+
+#include <Ext/Helper/Scripts.h>
+#include <Ext/Helper/Status.h>
+#include <Ext/Helper/Physics.h>
+#include <Ext/Helper/Weapon.h>
+#include <Ext/Helper/FLH.h>
+
+#include <Ext/ObjectType/AttachEffect.h>
+#include <Ext/EffectType/AttachEffectScript.h>
+#include <Ext/TechnoType/TechnoStatus.h>
+#include <Extension/TechnoExt.h>
+
+#include <Ext/BulletType/BulletStatus.h>
+
+// ============================================================================
+// 目标有效性辅助（SpawnMissile 场景专用）——照搬旧版
+// ============================================================================
+
+// 从引擎 Kamikaze 控制器读导弹的目标点（现有基建，不自己造轮子）：
+// KamikazeControl->Cell 存目标格子——Homing 开启时每帧更新（目标活着跟随、死亡冻结），
+// 不 Homing 时由引擎写入目标 Cell。这是引擎眼中导弹真正要飞向的位置
+static bool TryGetKamikazeTarget(TechnoClass* pTechno, CoordStruct& out)
+{
+	AircraftClass* pAircraft = pTechno ? abstract_cast<AircraftClass*>(pTechno) : nullptr;
+	if (!pAircraft)
+		return false;
+	auto& nodes = Kamikaze::Instance->Nodes;
+	for (int i = 0; i < nodes.Count; i++)
+	{
+		Kamikaze::KamikazeControl* pControl = nodes[i];
+		if (pControl && pControl->Item == pAircraft && pControl->Cell)
+		{
+			out = pControl->Cell->GetCoords();
+			return true;
+		}
+	}
+	return false;
+}
+
+// 从 spawn 发射者的管理器读目标（Kamikaze Cell 的源头）：
+// KamikazeTrackerClass_Add 就是用 SpawnManager->Destination 设置 Cell 的。
+// 导弹未全部发射（未进 Kamikaze 容器）期间容器为空，直接读源头补全这一阶段
+static bool TryGetSpawnManagerTarget(TechnoClass* pTechno, CoordStruct& out)
+{
+	if (pTechno && pTechno->SpawnOwner && !IsDeadOrInvisible(pTechno->SpawnOwner))
+	{
+		SpawnManagerClass* pSM = pTechno->SpawnOwner->SpawnManager;
+		if (pSM)
+		{
+			if (pSM->Target)
+			{
+				out = pSM->Target->GetCoords();
+				return true;
+			}
+			if (pSM->Destination)
+			{
+				out = pSM->Destination->GetCoords();
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+// ============================================================================
+// 生命周期
+// ============================================================================
+
+// 参照 MissileHoming 先例：注册 UnInit 事件，launcher/source 被删除时置空指针防悬垂
+void VectorEffect::Awake()
+{
+	EventSystems::General.AddHandler(Events::ObjectUnInitEvent, this, &VectorEffect::OnTechnoDelete);
+}
+
+void VectorEffect::Destroy()
+{
+	EventSystems::General.RemoveHandler(Events::ObjectUnInitEvent, this, &VectorEffect::OnTechnoDelete);
+}
+
+void VectorEffect::Clean()
+{
+	EffectScript::Clean();
+
+	_elapsedFrames = 0;
+	_moveFrame = 0;
+	_movementFrames = 0;
+	_effectiveTimeStep = 1;
+	_totalDuration = 0;
+
+	_initialLocation = {};
+	_initialOriginPos = {};
+	_initialBaseCenter = {};
+	_vectorAcquireZ = 0;
+	_pLauncher = nullptr;
+	_pSource = nullptr;
+
+	_facingRad = 0.0;
+	_facingDir = DirStruct(0);
+	_tiltRad = 0.0;
+
+	_originFacing = 0.0;
+	_originTilt = 0.0;
+
+	_randomTargetOffset = {};
+	_originTargetOffset = {};
+
+	_originOffset = {};
+	_prevCircleCenter = {};
+	_circlePos = {};
+
+	_motion = MotionState{};
+	_originMotion = MotionState{};
+}
+
+// ============================================================================
+// 公共数学函数（行为等价：逐字照搬旧版公式）
+// ============================================================================
+
+// 弧面旋转：arcDelta 按 Rodrigues 正交基分解到 XYZ。
+// D = 总位移向量，rotDeg = 弧面旋转角（0=纯 Z 朝上），arcDelta = 本帧弧高增量
+VectorEffect::ArcDelta3D VectorEffect::RotateArcDelta(const CoordStruct& D, double rotDeg, double arcDelta)
+{
+	ArcDelta3D out{ 0.0, 0.0, 0.0 };
+	if (rotDeg == 0.0)
+	{
+		out.z = arcDelta;
+		return out;
+	}
+	double dx = static_cast<double>(D.X);
+	double dy = static_cast<double>(D.Y);
+	double dz = static_cast<double>(D.Z);
+	double dLen = std::sqrt(dx * dx + dy * dy + dz * dz);
+	if (dLen <= 1e-6)
+	{
+		out.z = arcDelta;
+		return out;
+	}
+	double dnx = dx / dLen, dny = dy / dLen, dnz = dz / dLen;
+	double upDotD = dnz;
+	double px = -dnx * upDotD, py = -dny * upDotD, pz = 1.0 - dnz * upDotD;
+	double pLen = std::sqrt(px * px + py * py + pz * pz);
+	if (pLen < 1e-6)
+	{
+		px = 1.0 - dnx * dnx; py = -dny * dnx; pz = -dnz * dnx;
+		pLen = std::sqrt(px * px + py * py + pz * pz);
+	}
+	double pnx = px / pLen, pny = py / pLen, pnz = pz / pLen;
+	double rad = Math::deg2rad(rotDeg);
+	double c = std::cos(rad), s = std::sin(rad);
+	out.x = (pnx * c + (dny * pnz - dnz * pny) * s) * arcDelta;
+	out.y = (pny * c + (dnz * pnx - dnx * pnz) * s) * arcDelta;
+	out.z = (pnz * c + (dnx * pny - dny * pnx) * s) * arcDelta;
+	return out;
+}
+
+// 3D 法向量增量旋转（绕世界 F=Y / L=X / H=Z 轴，正速度=顺时针）
+void VectorEffect::RotateNormal3D(double& nx, double& ny, double& nz,
+	double stepF, double stepL, double stepH)
+{
+	if (stepF != 0.0)
+	{
+		double rad = Math::deg2rad(stepF), c = std::cos(rad), s = std::sin(rad);
+		double x = nx, z = nz;
+		nx = x * c - z * s;
+		nz = x * s + z * c;
+	}
+	if (stepL != 0.0)
+	{
+		double rad = Math::deg2rad(stepL), c = std::cos(rad), s = std::sin(rad);
+		double y = ny, z = nz;
+		ny = y * c + z * s;
+		nz = -y * s + z * c;
+	}
+	if (stepH != 0.0)
+	{
+		double rad = Math::deg2rad(stepH), c = std::cos(rad), s = std::sin(rad);
+		double x = nx, y = ny;
+		nx = x * c + y * s;
+		ny = -x * s + y * c;
+	}
+}
+
+// 法线角速度解析：常数优先 → 区间2 50% 随机 → 区间1 随机 → 0
+double VectorEffect::ResolveAngleStep(double perStep, double m1, double M1, double m2, double M2)
+{
+	if (perStep != 0.0) return perStep;
+	if (M1 <= m1 && M2 <= m2) return 0.0;
+	if (M2 > m2 && Random::RandomRanged(0, 1))
+		return m2 + (M2 - m2) * Random::RandomDouble();
+	return M1 > m1 ? m1 + (M1 - m1) * Random::RandomDouble() : 0.0;
+}
+
+// 三态跟踪：NoUpdate=yes → 冻结 last；no + 单位存活 → 每帧快照 last；死亡 → 冻结 last
+// 主 Origin（_initialOriginPos）与大圆基座（_initialBaseCenter）共用
+CoordStruct VectorEffect::TrackOriginCoord(ObjectClass* pUnit, bool noUpdate, CoordStruct& last)
+{
+	if (!noUpdate && pUnit && !IsDeadOrInvisible(pUnit))
+		last = pUnit->GetCoords();
+	return last;
+}
+
+// Target 多级读取链：缓存（跟随锁定单位）→ 弹体目标 → 弹体落点 → 单位目标 → Kamikaze/SpawnManager
+bool VectorEffect::GetTargetPosFromChain(CoordStruct& out, bool preferCache)
+{
+	if (preferCache && pTechno)
+	{
+		if (TechnoStatus* status = GetStatus<TechnoExt, TechnoStatus>(pTechno))
+		{
+			if (status->HasVectorTargetCache())
+			{
+				out = status->GetVectorCachedCell();
+				return true;
+			}
+		}
+	}
+	if (pBullet && pBullet->Target)
+	{
+		out = pBullet->Target->GetCoords(); // 抛射体目标 Cell 是真实落点
+		return true;
+	}
+	if (pBullet)
+	{
+		out = pBullet->TargetCoords;
+		return true;
+	}
+	if (pTechno && pTechno->Target)
+	{
+		out = pTechno->Target->GetCoords();
+		return true;
+	}
+	if (pTechno)
+	{
+		CoordStruct kamikazePos{};
+		if (TryGetKamikazeTarget(pTechno, kamikazePos) || TryGetSpawnManagerTarget(pTechno, kamikazePos))
+		{
+			out = kamikazePos;
+			return true;
+		}
+	}
+	return false;
+}
+
+// ============================================================================
+// 目标缓存（挂 TechnoStatus，归一目标保护）——照搬旧版
+// ============================================================================
+void VectorEffect::CacheTargetNow()
+{
+	if (!pTechno)
+		return;
+	TechnoStatus* status = GetStatus<TechnoExt, TechnoStatus>(pTechno);
+	if (!status)
+		return;
+
+	// --- 已有缓存：NoUpdate=no 只跟随锁定单位，不再读引擎参数 ---
+	if (status->HasVectorTargetCache())
+	{
+		// NoUpdate=yes：锁定第一笔，不刷新
+		if (Data->OriginNoUpdate)
+			return;
+		// NoUpdate=no：跟随锁定的单位实时位置（目标在导弹脚下也正常更新——真实目标就该下坠去打）
+		AbstractClass* pCachedTarget = status->GetVectorCachedTarget();
+		if (pCachedTarget)
+		{
+			TechnoClass* pTgt = abstract_cast<TechnoClass*>(pCachedTarget);
+			if (pTgt && !IsDeadOrInvisible(pTgt))
+			{
+				status->SetVectorTargetCache(pCachedTarget, pTgt->GetCoords());
+			}
+			// 目标死亡：不写，冻结最后有效格子
+		}
+		// 锁定的是格子（无单位）：格子不会移动，不刷新
+		return;
+	}
+
+	// --- 第一笔：引擎来源链取候选，优先单位 ---
+	AbstractClass* candTarget = nullptr;
+	CoordStruct candCell{};
+	bool got = false;
+
+	if (pTechno->SpawnOwner && !IsDeadOrInvisible(pTechno->SpawnOwner))
+	{
+		// Spawn 导弹：优先从发射者（SpawnOwner）自身攻击目标读——
+		// 引擎集结阶段 SpawnManager 的 Target/Destination 可能是集结点，发射者自己瞄准的目标才是真实目标
+		if (pTechno->SpawnOwner->Target)
+		{
+			TechnoClass* pTgt = abstract_cast<TechnoClass*>(pTechno->SpawnOwner->Target);
+			if (!pTgt || !IsDeadOrInvisible(pTgt)) // 非 Techno 目标（格子）不做死亡判断
+			{
+				candTarget = pTechno->SpawnOwner->Target;
+				candCell = pTechno->SpawnOwner->Target->GetCoords();
+				got = true;
+			}
+		}
+		// 原链兜底：SpawnManager（单位+坐标）→ Kamikaze Cell（只有格子）→ Target（单位+坐标）
+		SpawnManagerClass* pSM = pTechno->SpawnOwner->SpawnManager;
+		if (!got && pSM && pSM->Target)
+		{
+			TechnoClass* pTgt = abstract_cast<TechnoClass*>(pSM->Target);
+			if (!pTgt || !IsDeadOrInvisible(pTgt)) // 非 Techno 目标（格子）不做死亡判断
+			{
+				candTarget = pSM->Target;
+				candCell = pSM->Target->GetCoords();
+				got = true;
+			}
+		}
+		if (!got && pSM && pSM->Destination)
+		{
+			candCell = pSM->Destination->GetCoords();
+			got = true;
+		}
+		if (!got)
+		{
+			CoordStruct kamikazePos{};
+			if (TryGetKamikazeTarget(pTechno, kamikazePos))
+			{
+				candCell = kamikazePos;
+				got = true;
+			}
+		}
+		if (!got && pTechno->Target)
+		{
+			candTarget = pTechno->Target;
+			candCell = pTechno->Target->GetCoords();
+			got = true;
+		}
+	}
+	else if (pTechno->Target)
+	{
+		// 普通单位：直接记 Target
+		TechnoClass* pTgt = abstract_cast<TechnoClass*>(pTechno->Target);
+		if (!pTgt || !IsDeadOrInvisible(pTgt))
+		{
+			candTarget = pTechno->Target;
+			candCell = pTechno->Target->GetCoords();
+			got = true;
+		}
+	}
+
+	// 有效才写；取不到/目标死亡不写，保留最后有效值（冻结）
+	if (got)
+		status->SetVectorTargetCache(candTarget, candCell);
+}
+
+// ============================================================================
+// OnStart 子步骤
+// ============================================================================
+
+// 计时/快照/Duration/AcquireZ
+void VectorEffect::ParseCommon()
+{
+	_elapsedFrames = 0;
+	_moveFrame = 0;
+	_movementFrames = 0;
+	_effectiveTimeStep = Data->TimeStep;
+	// _prevCircleCenter 不在此初始化：圆心追踪依赖 Origin 移动系统首帧的 skipOriginUpdate 赋值
+
+	_initialLocation = pObject->GetCoords();
+	_vectorAcquireZ = _initialLocation.Z;  // Circle 圆心高度基准：获取 Vector 时的 Z
+	_totalDuration = AE->AEData.GetDuration() / _effectiveTimeStep;
+}
+
+// TargetOffset 随机偏移（Radius / F/L/H 两套 + Angles）——照搬旧版
+void VectorEffect::ParseTargetOffset()
+{
+	if (Data->TargetOffsetRadiusMin < Data->TargetOffsetRadiusMax)
+	{
+		// 半径模式：全向随机落点（与 F/L/H 互斥）
+		double radius = (Data->TargetOffsetRadiusMin2 < Data->TargetOffsetRadiusMax2 && Random::RandomRanged(0, 1))
+			? Random::RandomRanged(Data->TargetOffsetRadiusMin2, Data->TargetOffsetRadiusMax2)
+			: Random::RandomRanged(Data->TargetOffsetRadiusMin, Data->TargetOffsetRadiusMax);
+		if (Data->TargetOffsetSphere)
+		{
+			// 球面均匀分布：z=2u-1 面积均匀 + 经度 2πv，避免极区聚集
+			double u = Random::RandomDouble() * 2.0 - 1.0;
+			double phi = Random::RandomDouble() * 2.0 * M_PI;
+			double rXY = radius * std::sqrt(1.0 - u * u);
+			_randomTargetOffset.X = static_cast<int>(rXY * std::cos(phi));
+			_randomTargetOffset.Y = static_cast<int>(rXY * std::sin(phi));
+			_randomTargetOffset.Z = static_cast<int>(radius * u);
+		}
+		else
+		{
+			// XY 圆环：角度默认全向，TargetOffsetAngles 限制时按区间加权均匀
+			// 消费端 GetFLHAbsoluteOffset 世界角 = -(mainFacingDir + flhAngle)，要求 = 近交点角 + deg：
+			// flhAngle = -mainFacingDirSim - β - deg
+			//   β = atan2 近交点世界角（目标点指向抛射体）
+			//   mainFacingDirSim = 消费端 mainFacingDir 统一取 DirStruct 原值（NoUpdate 不影响坐标系）
+			double flhAngle;
+			bool hasAngleRange = (Data->TargetOffsetAngleMin < Data->TargetOffsetAngleMax)
+				|| (Data->TargetOffsetAngleMin2 < Data->TargetOffsetAngleMax2);
+			if (hasAngleRange)
+			{
+				// 区间加权均匀：u 落在总长度内，映射到对应区间
+				double len1 = Data->TargetOffsetAngleMax - Data->TargetOffsetAngleMin;
+				double len2 = Data->TargetOffsetAngleMax2 - Data->TargetOffsetAngleMin2;
+				double total = (len1 > 0 ? len1 : 0.0) + (len2 > 0 ? len2 : 0.0);
+				double u = Random::RandomDouble() * total;
+				double deg;
+				if (len1 > 0 && u < len1)
+					deg = Data->TargetOffsetAngleMin + u;
+				else
+					deg = Data->TargetOffsetAngleMin2 + (u - (len1 > 0 ? len1 : 0.0));
+				// 近交点基准：targetPos 取 pBullet->TargetCoords（与 OnStart 326 行 _facingDir 一致）
+				bool hasBase = false;
+				CoordStruct bulletPos = pObject->GetCoords();
+				CoordStruct targetPos{};
+				if (pBullet)
+				{
+					targetPos = pBullet->TargetCoords;
+					hasBase = true;
+				}
+				else if (pTechno && pTechno->Target)
+				{
+					targetPos = pTechno->Target->GetCoords();
+					hasBase = true;
+				}
+				if (hasBase)
+				{
+					double beta = std::atan2(bulletPos.Y - targetPos.Y, bulletPos.X - targetPos.X); // 近交点世界角
+					double alpha = Point2Dir(targetPos, bulletPos).GetRadian(); // 近交点 DirStruct 角
+					// 消费端 mainFacingDir 统一取 DirStruct 原值（NoUpdate 不影响坐标系），直接复刻
+					double mainFacingDirSim = alpha;
+					flhAngle = -mainFacingDirSim - beta - Math::deg2rad(deg);
+				}
+				else
+				{
+					flhAngle = Random::RandomDouble() * 2.0 * M_PI; // 拿不到连线方向：回退全向
+				}
+			}
+			else
+			{
+				flhAngle = Random::RandomDouble() * 2.0 * M_PI;  // 无角度限制：全向
+			}
+			_randomTargetOffset.X = static_cast<int>(radius * std::cos(flhAngle));
+			_randomTargetOffset.Y = static_cast<int>(radius * std::sin(flhAngle));
+			_randomTargetOffset.Z = (Data->TargetOffsetHMin2 < Data->TargetOffsetHMax2 && Random::RandomRanged(0, 1))
+				? Random::RandomRanged(Data->TargetOffsetHMin2, Data->TargetOffsetHMax2)
+				: (Data->TargetOffsetHMin < Data->TargetOffsetHMax
+					? Random::RandomRanged(Data->TargetOffsetHMin, Data->TargetOffsetHMax) : 0);
+		}
+	}
+	else
+	{
+		// F/L/H 模式：区间2有效且50%取区间2，否则区间1（无效给0）
+		_randomTargetOffset.X = (Data->TargetOffsetFMin2 < Data->TargetOffsetFMax2 && Random::RandomRanged(0, 1))
+			? Random::RandomRanged(Data->TargetOffsetFMin2, Data->TargetOffsetFMax2)
+			: (Data->TargetOffsetFMin < Data->TargetOffsetFMax
+				? Random::RandomRanged(Data->TargetOffsetFMin, Data->TargetOffsetFMax) : 0);
+		_randomTargetOffset.Y = (Data->TargetOffsetLMin2 < Data->TargetOffsetLMax2 && Random::RandomRanged(0, 1))
+			? Random::RandomRanged(Data->TargetOffsetLMin2, Data->TargetOffsetLMax2)
+			: (Data->TargetOffsetLMin < Data->TargetOffsetLMax
+				? Random::RandomRanged(Data->TargetOffsetLMin, Data->TargetOffsetLMax) : 0);
+		_randomTargetOffset.Z = (Data->TargetOffsetHMin2 < Data->TargetOffsetHMax2 && Random::RandomRanged(0, 1))
+			? Random::RandomRanged(Data->TargetOffsetHMin2, Data->TargetOffsetHMax2)
+			: (Data->TargetOffsetHMin < Data->TargetOffsetHMax
+				? Random::RandomRanged(Data->TargetOffsetHMin, Data->TargetOffsetHMax) : 0);
+	}
+}
+
+// 弧参数三件套（rotation/height/peakPercent 随机解析）——照搬旧版
+// origin=false 主，true 大圆
+void VectorEffect::ParseArcParams(bool origin)
+{
+	if (!origin)
+	{
+		// --- 主弧参数 ---
+		_motion.arcRotation = Data->ArcRotation;
+		if (Data->ArcRandomRotationMax > Data->ArcRandomRotationMin)
+			_motion.arcRotation = Data->ArcRandomRotationMin + (Data->ArcRandomRotationMax - Data->ArcRandomRotationMin) * Random::RandomDouble();
+
+		_motion.arcHeight = Data->ArcHeight;
+		if (Data->ArcRandomHeightMax > Data->ArcRandomHeightMin)
+			_motion.arcHeight = Random::RandomRanged(Data->ArcRandomHeightMin, Data->ArcRandomHeightMax);
+
+		_motion.arcPeakPercent = Data->ArcPeakPercent / 100.0;
+		if (Data->ArcPeakRandomPercent.X < Data->ArcPeakRandomPercent.Y)
+			_motion.arcPeakPercent = Random::RandomRanged(Data->ArcPeakRandomPercent.X, Data->ArcPeakRandomPercent.Y) / 100.0;
+		if (_motion.arcPeakPercent <= 0.0) _motion.arcPeakPercent = 0.5;
+		if (_motion.arcPeakPercent >= 1.0) _motion.arcPeakPercent = 0.5;
+	}
+	else
+	{
+		// --- 大圆弧参数（镜像主弧）---
+		_originMotion.arcRotation = Data->OriginArcRotation;
+		if (Data->OriginArcRandomRotationMax > Data->OriginArcRandomRotationMin)
+			_originMotion.arcRotation = Data->OriginArcRandomRotationMin + (Data->OriginArcRandomRotationMax - Data->OriginArcRandomRotationMin) * Random::RandomDouble();
+
+		_originMotion.arcHeight = Data->OriginArcHeight;
+		if (Data->OriginArcRandomHeightMax > Data->OriginArcRandomHeightMin)
+			_originMotion.arcHeight = Random::RandomRanged(Data->OriginArcRandomHeightMin, Data->OriginArcRandomHeightMax);
+
+		_originMotion.arcPeakPercent = Data->OriginArcPeakPercent / 100.0;
+		if (Data->OriginArcPeakRandomPercent.X < Data->OriginArcPeakRandomPercent.Y)
+			_originMotion.arcPeakPercent = Random::RandomRanged(Data->OriginArcPeakRandomPercent.X, Data->OriginArcPeakRandomPercent.Y) / 100.0;
+		if (_originMotion.arcPeakPercent <= 0.0) _originMotion.arcPeakPercent = 0.5;
+		if (_originMotion.arcPeakPercent >= 1.0) _originMotion.arcPeakPercent = 0.5;
+	}
+}
+
+// 初始速度（LinearSpeed/单位 Speed/弹体 Speed/随机）——照搬旧版
+void VectorEffect::ParseSpeed()
+{
+	_motion.speed = 0.0;
+	if (Data->LinearSpeed >= 0)
+	{
+		_motion.speed = static_cast<double>(Data->LinearSpeed);
+	}
+	else if (pTechno)
+	{
+		TechnoTypeClass* pType = pTechno->GetTechnoType();
+		if (GetLocoType(pTechno) == LocoType::Jumpjet)
+			_motion.speed = pType->JumpjetSpeed;
+		else
+			_motion.speed = pType->Speed;
+	}
+	else if (pBullet)
+	{
+		_motion.speed = pBullet->Speed;
+	}
+	// Speed 模式随机速度
+	if (Data->RandomSpeedMax > Data->RandomSpeedMin)
+	{
+		_motion.speed = Random::RandomRanged(Data->RandomSpeedMin, Data->RandomSpeedMax);
+	}
+}
+
+// 基础参考系 + 目标缓存 + 按 Origin 锁定基线——照搬旧版
+void VectorEffect::InitOrigin()
+{
+	// --- 基础参考系（始终赋值，供 OriginOrigin 等使用） ---
+	if (pBullet)
+	{
+		_pLauncher = pBullet->Owner;
+		if (AE && AE->pSource) _pSource = AE->pSource;
+	}
+	else if (pTechno)
+	{
+		_pLauncher = (AE && AE->pSource) ? AE->pSource : pTechno; // 单位侧用攻击者作为Launcher
+	}
+
+	// 挂载即初始化目标缓存（无论本段 Origin 是不是 Target，都记录）
+	// 保证后续 Target 段（可能目标已死）有坐标可读；NoUpdate=yes 时这里就是"存一次即停"的第一笔
+	CacheTargetNow();
+
+	// --- Origin 初始化：锁定基线 ---
+	switch (Data->Origin)
+	{
+	case VectorData::VectorOrigin::Target:
+		// 无论 NoUpdate 都锁定基线（OnStart 时引擎目标还是真实的）：NoUpdate=yes 直接用它，
+		// no 每帧刷新覆盖；引擎目标失效时回退此基线（保证打地面轨迹一致）
+		// 锚点 = 引擎 Kamikaze 控制器存的目标点（Homing 更新/引擎写入，目标死亡冻结）→ 攻击目标 → 自身
+		if (pTechno)
+		{
+			CoordStruct kamikazePos{};
+			bool gotKamikaze = TryGetKamikazeTarget(pTechno, kamikazePos);
+			// ① TechnoStatus 目标缓存（挂载时固化；只读格子，目标死活不影响）
+			TechnoStatus* cacheStatus = GetStatus<TechnoExt, TechnoStatus>(pTechno);
+			if (cacheStatus && cacheStatus->HasVectorTargetCache())
+			{
+				_initialOriginPos = cacheStatus->GetVectorCachedCell();
+			}
+			else if (gotKamikaze)
+			{
+				_initialOriginPos = kamikazePos;
+			}
+			else if (TryGetSpawnManagerTarget(pTechno, _initialOriginPos))
+			{
+				// 未进 Kamikaze 容器（导弹未全部发射）时读源头：SpawnManager 目标
+			}
+			else if (pTechno->Target)
+			{
+				_initialOriginPos = pTechno->Target->GetCoords();
+			}
+			else
+			{
+				// Kamikaze 容器此刻可能还没加入导弹（发射后才加入）：不锁自身，
+				// 留空由 GetVectorResult 首帧补读
+				_initialOriginPos = CoordStruct::Empty;
+			}
+		}
+		else if (pBullet)
+		{
+			_initialOriginPos = pBullet->TargetCoords;
+		}
+		else
+		{
+			_initialOriginPos = pObject->GetCoords();
+		}
+		break;
+
+	case VectorData::VectorOrigin::Launcher:
+		// 无论 NoUpdate 都锁定基线（与 Target 分支一致）：NoUpdate=yes 直接用，
+		// no 每帧快照刷新覆盖；launcher 死亡时冻结此基线作为 origin 解算起点
+		if (pBullet && pBullet->Owner)
+			_initialOriginPos = pBullet->Owner->GetCoords();
+		else if (pTechno)
+			_initialOriginPos = pTechno->GetCoords();
+		else
+			_initialOriginPos = pObject->GetCoords();
+		break;
+
+	case VectorData::VectorOrigin::Source:
+		// 无论 NoUpdate 都锁定基线（与 Target/Launcher 分支一致）：死亡时冻结此基线
+		if (AE && AE->pSource)
+			_initialOriginPos = AE->pSource->GetCoords();
+		else
+			_initialOriginPos = pObject->GetCoords(); // 兜底与 Target 分支一致
+		if (AE && AE->pSource)
+			_pSource = AE->pSource;
+		break;
+
+	case VectorData::VectorOrigin::Self:
+		if (pBullet)
+		{
+			double bulletRad = std::atan2(pBullet->Velocity.X, pBullet->Velocity.Y);
+			DirStruct bulletFacing;
+			bulletFacing.SetValue(static_cast<short>(bulletRad * 32768.0 / M_PI));
+			_initialOriginPos = GetFLHAbsoluteCoords(pBullet->GetCoords(), Data->OriginFLH, bulletFacing);
+			_facingDir = bulletFacing; // 锁定初始朝向
+			_facingRad = _facingDir.GetRadian();
+		}
+		else if (pTechno)
+		{
+			CoordStruct unitPos = pTechno->GetCoords();
+			DirStruct unitFacing = pTechno->TurretFacing().Current();
+			_initialOriginPos = GetFLHAbsoluteCoords(unitPos, Data->OriginFLH, unitFacing);
+			_facingDir = unitFacing; // 锁定初始朝向
+			_facingRad = _facingDir.GetRadian();
+		}
+		break;
+	}
+}
+
+// 朝向锁定：NormalVector 处理 + 法向量初始化 + 角速度解析 + 非 Normal 的 Origin 朝向——照搬旧版
+void VectorEffect::LockFacing()
+{
+	// NormalVector 设为后，F 轴完全由向量决定，Origin 只控制原点位置
+	bool hasNormal = !Data->NormalVector.IsEmpty()
+		|| Data->NormalRandomF.Y > Data->NormalRandomF.X
+		|| Data->NormalRandomL.Y > Data->NormalRandomL.X
+		|| Data->NormalRandomH.Y > Data->NormalRandomH.X;
+
+	// --- 锁定 FLH 旋转朝向（OnStart 时固定） ---
+	// NormalVector 使用 FLH 坐标系：F=南北(X→世界Y)，L=东西(Y→世界X)，H=Z
+	if (hasNormal)
+	{
+		double fwY = static_cast<double>(Data->NormalVector.X);  // F → 世界 Y（北）
+		double fwX = static_cast<double>(Data->NormalVector.Y);  // L → 世界 X（东）
+		double fwZ = static_cast<double>(Data->NormalVector.Z);  // H → Z
+
+		// 随机分量
+		if (Data->NormalRandomF.Y > Data->NormalRandomF.X)
+			fwY = Random::RandomRanged(Data->NormalRandomF.X, Data->NormalRandomF.Y);
+		if (Data->NormalRandomL.Y > Data->NormalRandomL.X)
+			fwX = Random::RandomRanged(Data->NormalRandomL.X, Data->NormalRandomL.Y);
+		if (Data->NormalRandomH.Y > Data->NormalRandomH.X)
+			fwZ = Random::RandomRanged(Data->NormalRandomH.X, Data->NormalRandomH.Y);
+
+		double lenXY = std::sqrt(fwX * fwX + fwY * fwY);
+		_facingRad = lenXY > 1e-6 ? std::atan2(fwY, fwX) : 0.0;
+		_tiltRad = lenXY > 1e-6 ? std::atan2(fwZ, lenXY) : (fwZ > 0 ? M_PI / 2.0 : -M_PI / 2.0);
+	}
+	else
+	{
+		_tiltRad = 0.0;
+	}
+
+	// 法线旋转角速度解析（常数优先，否则随机）
+	_motion.normalStepF = ResolveAngleStep(Data->NormalFAnglePerStep, Data->NormalFAngleRMin, Data->NormalFAngleRMax, Data->NormalFAngleRMin2, Data->NormalFAngleRMax2);
+	_motion.normalStepL = ResolveAngleStep(Data->NormalLAnglePerStep, Data->NormalLAngleRMin, Data->NormalLAngleRMax, Data->NormalLAngleRMin2, Data->NormalLAngleRMax2);
+	_motion.normalStepH = ResolveAngleStep(Data->NormalHAnglePerStep, Data->NormalHAngleRMin, Data->NormalHAngleRMax, Data->NormalHAngleRMin2, Data->NormalHAngleRMax2);
+	_motion.lissajousStep = Data->Lissajous;
+
+	// 初始化 3D 法向量（从球坐标 _facingRad/_tiltRad 转换）
+	// 球坐标→笛卡尔：X=cos(tilt)cos(facing), Y=cos(tilt)sin(facing), Z=sin(tilt)
+	{
+		double ct = std::cos(_tiltRad), st = std::sin(_tiltRad);
+		double cf = std::cos(_facingRad), sf = std::sin(_facingRad);
+		_motion.normalX = ct * cf;
+		_motion.normalY = ct * sf;
+		_motion.normalZ = st;
+	}
+
+	// --- 非 Normal 的 Origin 朝向锁定 ---
+	if (!hasNormal)
+	{
+		switch (Data->Origin)
+		{
+		case VectorData::VectorOrigin::Launcher:
+		{
+			TechnoClass* pLauncherTechno = abstract_cast<TechnoClass*>(_pLauncher);
+			if (pLauncherTechno && !IsDeadOrInvisible(pLauncherTechno))
+			{
+				_facingDir = pLauncherTechno->TurretFacing().Current(); // 直接存 DirStruct，不经 GetRadian 往返
+				_facingRad = _facingDir.GetRadian();
+			}
+			break;
+		}
+
+		case VectorData::VectorOrigin::Target:
+		{
+			// 射手角色 = 附着对象自身；F 轴 = Point2Dir(攻击目标, 弹体)。无攻击目标不锁定（保持默认朝向）
+			if (pTechno && pTechno->Target)
+			{
+				CoordStruct targetPos = pTechno->Target->GetCoords();
+				CoordStruct sourcePos = pTechno->GetCoords(); // 射手角色 = 自身
+				_facingDir = Point2Dir(targetPos, sourcePos); // 官方API，不得修改
+				_facingRad = _facingDir.GetRadian();
+			}
+			else if (pBullet)
+			{
+				CoordStruct bulletPos = pBullet->GetCoords();
+				CoordStruct targetPos = pBullet->TargetCoords;
+				_facingDir = Point2Dir(targetPos, bulletPos); // 官方API，不得修改
+				_facingRad = _facingDir.GetRadian();
+			}
+			break;
+		}
+
+		case VectorData::VectorOrigin::Source:
+		{
+			// 与 Target 模式对齐：F 轴 = Origin(Source) → 弹体 方向（每帧 no 路径同向，NoUpdate 切换不再镜像）
+			if (pBullet && AE && AE->pSource)
+			{
+				_facingDir = Point2Dir(AE->pSource->GetCoords(), pBullet->GetCoords()); // 官方API
+				_facingRad = _facingDir.GetRadian();
+			}
+			else if (pTechno && AE && AE->pSource)
+			{
+				_facingDir = Point2Dir(AE->pSource->GetCoords(), pTechno->GetCoords()); // 官方API
+				_facingRad = _facingDir.GetRadian();
+			}
+			break;
+		}
+
+		default: // FLH：抛射体自身朝向
+		{
+			if (pBullet)
+				_facingRad = std::atan2(pBullet->Velocity.X, pBullet->Velocity.Y);
+			else if (pTechno)
+				_facingRad = pTechno->TurretFacing().Current().GetRadian();
+			break;
+		}
+		}
+	}
+}
+
+// ============================================================================
+// OnStart：编排
+// ============================================================================
+void VectorEffect::OnStart()
+{
+	if (pTechno && pTechno->WhatAmI() == AbstractType::Building)
+	{
+		Deactivate();
+		return;
+	}
+
+	ParseCommon();
+
+	// 影子坐标（Speed 模式弧高进度基准，不受弧高 Z 偏移污染）
+	_motion.shadowX = _initialLocation.X;
+	_motion.shadowY = _initialLocation.Y;
+	_motion.shadowZ = _initialLocation.Z;
+	_motion.shadowTraveled = 0.0;
+
+	ParseTargetOffset();
+	ParseArcParams(false); // 主弧
+	ParseArcParams(true);  // 大圆弧
+	ParseSpeed();
+	InitOrigin();
+	LockFacing();
+}
+
+// ============================================================================
+VectorResult VectorEffect::GetVectorResult()
+{
+	VectorResult result;
+
+	// 首帧快照（仅一次，供弧高计算等）
+	if (_elapsedFrames == 0)
+		_initialLocation = pObject->GetCoords();
+
+	// InitialDelay 期间 AE 存在但未启动，不施加任何位移
+	if (!_started)
+	{
+		AdvanceFrame();
+		return result;
+	}
+
+	// 每帧运动刷新目标缓存：挂载时（OnStart）已写第一笔，这里跟随目标移动刷新；
+	// 目标死亡时停止写入，冻结最后有效值
+	CacheTargetNow();
+
+	// 目标坐标固化：OnStart 未锁定（Pending）时补读，读到即锁定到 _initialOriginPos，
+	// 防止引擎后续清空（目标死亡/管理器清空）导致 frameTarget 失效
+	if (Data->Origin == VectorData::VectorOrigin::Target
+		&& _initialOriginPos.IsEmpty() && pTechno)
+	{
+		CoordStruct targetPos{};
+		bool got = false;
+		if (TechnoStatus* status = GetStatus<TechnoExt, TechnoStatus>(pTechno))
+		{
+			if (status->HasVectorTargetCache())
+			{
+				targetPos = status->GetVectorCachedCell();
+				got = true;
+			}
+		}
+		if (!got && TryGetKamikazeTarget(pTechno, targetPos)) got = true;
+		if (!got && TryGetSpawnManagerTarget(pTechno, targetPos)) got = true;
+		if (!got && pTechno->Target) { targetPos = pTechno->Target->GetCoords(); got = true; }
+		if (got)
+		{
+			_initialOriginPos = targetPos;
+		}
+	}
+
+	// Force 必须在闸门之前设，确保非运动帧也走 SetLocation（Freeze 等效）
+	result.Force = Data->Force;
+	result.AllowFallingDestroy = Data->AllowFallingDestroy;
+	result.FallingDestroyHeight = Data->FallingDestroyHeight;
+	result.AllowRotateUnit = Data->SyncFacing; // 成熟机制：单位端同步朝向，删改前确认
+
+	// Circle 预初始化：在 DisabledFrames 冻结前完成，保证首帧后参数可用
+	if (_elapsedFrames == 0)
+	{
+		_motion.circleSpeed = static_cast<double>(Data->CircleSpeed);
+		if (_motion.circleSpeed <= 0.0)
+		{
+			if (pBullet)
+				_motion.circleSpeed = pBullet->Speed;
+			else if (pTechno)
+				_motion.circleSpeed = pTechno->GetTechnoType()->Speed;
+		}
+		_motion.circleAngle = Data->CircleAnglePerStep;
+		if (Data->CircleRandomAngleMax > Data->CircleRandomAngleMin)
+		{
+			if (Data->CircleRandomAngleMax2 > Data->CircleRandomAngleMin2 && Random::RandomRanged(0, 1))
+				_motion.circleAngle = Data->CircleRandomAngleMin2 + (Data->CircleRandomAngleMax2 - Data->CircleRandomAngleMin2) * Random::RandomDouble();
+			else
+				_motion.circleAngle = Data->CircleRandomAngleMin + (Data->CircleRandomAngleMax - Data->CircleRandomAngleMin) * Random::RandomDouble();
+		}
+		_motion.circleRadius = static_cast<double>(Data->CircleRadius);
+		if (Data->CircleRandomRadiusMax > Data->CircleRandomRadiusMin)
+			_motion.circleRadius = Random::RandomRanged(Data->CircleRandomRadiusMin, Data->CircleRandomRadiusMax);
+	}
+
+	// DisabledFrames：首帧快照后冻结，不阻塞其他 AE，不计入运动时间
+	if (_elapsedFrames < Data->DisabledFrames)
+	{
+		result.MoveDisp = { 0, 0, 0 };
+		AdvanceFrame();
+		return result;
+	}
+
+	// ========================================================================
+	// Freeze — 成熟机制，别乱动
+	// ========================================================================
+	if (Data->Freeze)
+	{
+		result.Freeze = true;
+		result.Force = true;  // 抛射体 Freeze 必须 Force，否则引擎检测"卡住"自爆
+		if (result.FrozenPos.IsEmpty())
+			result.FrozenPos = _initialLocation;
+		CoordStruct currentPos = pObject->GetCoords();
+		result.MoveDisp = result.FrozenPos - currentPos;
+		return result;
+	}
+
+	// ========================================================================
+	// TimeStep 闸门
+	// ========================================================================
+	if (!ShouldMoveThisFrame())
+	{
+		_moveFrame++;
+		return result;
+	}
+	_movementFrames++;
+
+	_motion.normalRotF += _motion.lissajousStep;
+	// 3D 法向量增量旋转（绕世界 F=Y / L=X / H=Z 轴，正速度=顺时针）
+	if (_motion.normalStepF != 0.0 || _motion.normalStepL != 0.0 || _motion.normalStepH != 0.0)
+	{
+		RotateNormal3D(_motion.normalX, _motion.normalY, _motion.normalZ,
+			_motion.normalStepF, _motion.normalStepL, _motion.normalStepH);
+	}
+
+	CoordStruct currentPos = pObject->GetCoords();
+
+	// ========================================================================
+	// 动态 F 轴：非 NoUpdate 时每帧根据当前坐标重新计算 FLH 朝向
+	// ========================================================================
+
+	// AllowOriginTilt：从 Origin 单位获取倾斜，注入 _facingRad/_tiltRad（同 NormalVector 机制）
+	// 仅 Circle 模式生效，避免非 Circle 模式覆盖 OnStart 的方向
+	double originTerrainTilt = 0.0;
+	bool hasCircleForTilt = Data->CircleRadius > 0 || Data->CircleAnglePerStep > 0.0
+		|| (Data->CircleRandomRadiusMax > Data->CircleRandomRadiusMin)
+		|| (Data->CircleRandomAngleMax > Data->CircleRandomAngleMin);
+	if ((Data->AllowOriginTilt || Data->OriginAllowOriginTilt) && hasCircleForTilt && !Data->OriginIsOnWorld)
+	{
+		TechnoClass* pOriginTechno = nullptr;
+		switch (Data->Origin)
+		{
+		case VectorData::VectorOrigin::Target:
+			if (pBullet && pBullet->Target)
+				pOriginTechno = abstract_cast<TechnoClass*>(pBullet->Target);
+			else if (pTechno && pTechno->Target)
+				pOriginTechno = abstract_cast<TechnoClass*>(pTechno->Target);
+			break;
+		case VectorData::VectorOrigin::Source:
+			pOriginTechno = abstract_cast<TechnoClass*>(_pSource);
+			break;
+		case VectorData::VectorOrigin::Launcher:
+			pOriginTechno = abstract_cast<TechnoClass*>(_pLauncher);
+			break;
+		case VectorData::VectorOrigin::Self:
+			pOriginTechno = pTechno;
+			break;
+		}
+		if (pOriginTechno && !IsDeadOrInvisible(pOriginTechno))
+		{
+			// 优先用引擎动态倾斜（Rocker等），为 0 时从地形采样
+			originTerrainTilt = pOriginTechno->AngleRotatedForwards;
+			if (std::abs(originTerrainTilt) < 1e-6)
+			{
+				CoordStruct originCoord = pOriginTechno->GetCoords();
+				double unitFacing = pOriginTechno->PrimaryFacing.Current().GetRadian();
+				double cosF = std::cos(unitFacing), sinF = std::sin(unitFacing);
+				Point2D frontPt = { originCoord.X + static_cast<int>(128.0 * cosF), originCoord.Y + static_cast<int>(128.0 * sinF) };
+				Point2D backPt  = { originCoord.X - static_cast<int>(128.0 * cosF), originCoord.Y - static_cast<int>(128.0 * sinF) };
+				int hFront = MapClass::Instance->GetCellFloorHeight({frontPt.X, frontPt.Y, 0});
+				int hBack  = MapClass::Instance->GetCellFloorHeight({backPt.X, backPt.Y, 0});
+				double dz = static_cast<double>(hFront - hBack);
+				double dxy = 256.0;
+				originTerrainTilt = (dxy > 1e-6) ? std::atan2(dz, dxy) : 0.0;
+			}
+
+			// 注入 _facingRad/_tiltRad（同 NormalVector 机制）
+			// 单位倾斜 = 默认法向量 (0,0,1) 绕单位 L 轴旋转 originTerrainTilt
+			// L 轴 = (-sinF, cosF, 0)，绕 L 轴旋转后法向量 = (-sinT*sinF, sinT*cosF, cosT)
+			double unitFacing2 = pOriginTechno->PrimaryFacing.Current().GetRadian();
+			double sinT = std::sin(originTerrainTilt), cosT = std::cos(originTerrainTilt);
+			double nx = -sinT * std::sin(unitFacing2);
+			double ny = sinT * std::cos(unitFacing2);
+			double nz = cosT;
+			double nLenXY = std::sqrt(nx * nx + ny * ny);
+			_facingRad = nLenXY > 1e-6 ? std::atan2(ny, nx) : 0.0;
+			_tiltRad = nLenXY > 1e-6 ? std::atan2(nz, nLenXY) : (nz > 0 ? M_PI / 2.0 : -M_PI / 2.0);
+		}
+	}
+
+	double effectiveFacing = _facingRad;
+	double effectiveTilt = _tiltRad;
+	DirStruct mainFacingDir = Radians2Dir(effectiveFacing); // 官方API，不得修改：引擎弧度→DirStruct转换
+	// Target/Source/Launcher/Self：统一用 OnStart 存的 DirStruct 作基础朝向。
+	// Radians2Dir(GetRadian()) 往返存在 90° 偏置（BINARY_ANGLE_MAGIC 为负），
+	// NoUpdate=no 时误走该路径导致坐标系旋转。NoUpdate 只决定原点是否动态刷新，不影响坐标系计算。
+	bool hasNormal = !Data->NormalVector.IsEmpty()
+		|| Data->NormalRandomF.Y > Data->NormalRandomF.X
+		|| Data->NormalRandomL.Y > Data->NormalRandomL.X
+		|| Data->NormalRandomH.Y > Data->NormalRandomH.X;
+	if (!hasNormal && (Data->Origin == VectorData::VectorOrigin::Target
+		|| Data->Origin == VectorData::VectorOrigin::Source
+		|| Data->Origin == VectorData::VectorOrigin::Launcher
+		|| Data->Origin == VectorData::VectorOrigin::Self))
+	{
+		mainFacingDir = _facingDir;
+		effectiveFacing = _facingDir.GetRadian();
+	}
+
+	// OriginIsOnWorld：锁定世界坐标系（朝北），覆盖 Origin 朝向
+	if (Data->OriginIsOnWorld)
+	{
+		mainFacingDir = DirStruct{};
+		effectiveFacing = 0.0;
+		effectiveTilt = 0.0;
+	}
+
+	// 统一朝向算法：NoUpdate 只切换计算点（锁定 _initialOriginPos vs 实时坐标），不切换坐标系/朝向算法
+	if (!hasNormal && !Data->AllowOriginTilt && !Data->OriginIsOnWorld)
+	{
+		switch (Data->Origin)
+		{
+		case VectorData::VectorOrigin::Source:
+			// 计算点：NoUpdate=yes 用锁定值，no 每帧刷新（三态跟踪：死亡冻结）
+			TrackOriginCoord(_pSource, Data->OriginNoUpdate, _initialOriginPos);
+			if (!_initialOriginPos.IsEmpty())
+			{
+				// 来源活着或已死亡：都用快照算朝向（死亡后冻结指向死亡点）
+				mainFacingDir = Point2Dir(_initialOriginPos, currentPos); // 官方API，不得修改
+				effectiveFacing = mainFacingDir.GetRadian();
+				double dx = currentPos.X - _initialOriginPos.X;
+				double dy = currentPos.Y - _initialOriginPos.Y;
+				double dz = currentPos.Z - _initialOriginPos.Z;
+				double lenXY = std::sqrt(dx*dx + dy*dy);
+				effectiveTilt = (lenXY > 1e-6 && Data->AllowCircleTilt) ? std::atan2(dz, lenXY) : 0.0;
+			}
+			break;
+		case VectorData::VectorOrigin::Target:
+		{
+			bool isGround = (pBullet && !abstract_cast<TechnoClass*>(pBullet->Target));
+			if (isGround && _movementFrames > 1)
+				break;
+			// 计算点：默认锁定值起步，NoUpdate=no 才走缓存/引擎链动态获取
+			CoordStruct targetPos = _initialOriginPos;
+			bool gotTarget = !targetPos.IsEmpty();
+			if (!gotTarget && !Data->OriginNoUpdate)
+			{
+				gotTarget = GetTargetPosFromChain(targetPos, true);
+			}
+			if (gotTarget)
+				_initialOriginPos = targetPos; // 跟随：更新锁定值
+			else if (targetPos.IsEmpty())
+				break; // 从未有过目标：保持朝向
+			mainFacingDir = Point2Dir(targetPos, currentPos); // 官方API，不得修改
+			effectiveFacing = mainFacingDir.GetRadian();
+			double dx = currentPos.X - targetPos.X, dy = currentPos.Y - targetPos.Y, dz = currentPos.Z - targetPos.Z;
+			double lenXY = std::sqrt(dx*dx + dy*dy);
+			effectiveTilt = (lenXY > 1e-6 && Data->AllowCircleTilt) ? std::atan2(dz, lenXY) : 0.0;
+		}
+			break;
+
+		case VectorData::VectorOrigin::Self:
+			if (pTechno)
+			{
+				mainFacingDir = Data->OriginIsOnBody
+					? pTechno->PrimaryFacing.Current()     // 官方API，不得修改
+					: pTechno->TurretFacing().Current();   // 官方API，不得修改
+				effectiveFacing = mainFacingDir.GetRadian();
+			}
+			else if (pBullet)
+			{
+				mainFacingDir = Facing(pBullet, currentPos); // 官方API，不得修改
+				effectiveFacing = mainFacingDir.GetRadian();
+			}
+			break;
+
+		case VectorData::VectorOrigin::Launcher:
+			if (_pLauncher && !IsDeadOrInvisible(_pLauncher))
+			{
+				TechnoClass* pLauncherTechno = abstract_cast<TechnoClass*>(_pLauncher);
+				if (pLauncherTechno)
+				{
+					mainFacingDir = Data->OriginIsOnBody
+						? pLauncherTechno->PrimaryFacing.Current()     // 官方API，不得修改
+						: pLauncherTechno->TurretFacing().Current();   // 官方API，不得修改
+					effectiveFacing = mainFacingDir.GetRadian();
+				}
+			}
+			break;
+		}
+	}
+
+	// 3D 法向量旋转覆盖：当 NormalF/L/HAnglePerStep 设定时，无视基座变化
+	if (_motion.normalStepF != 0.0 || _motion.normalStepL != 0.0 || _motion.normalStepH != 0.0)
+	{
+		double lenXY = std::sqrt(_motion.normalX * _motion.normalX + _motion.normalY * _motion.normalY);
+		effectiveFacing = lenXY > 1e-6 ? std::atan2(_motion.normalY, _motion.normalX) : 0.0;
+		effectiveTilt = lenXY > 1e-6 ? std::atan2(_motion.normalZ, lenXY) : (_motion.normalZ > 0 ? M_PI / 2.0 : -M_PI / 2.0);
+		mainFacingDir = Radians2Dir(effectiveFacing); // 官方API，不得修改
+	}
+
+	// ========================================================================
+	// Origin 坐标（主 Origin 计算点）
+	// ========================================================================
+	CoordStruct originPos = currentPos;
+
+	switch (Data->Origin)
+	{
+	case VectorData::VectorOrigin::Target:
+		if (Data->OriginNoUpdate)
+			originPos = _initialOriginPos.IsEmpty() ? currentPos : _initialOriginPos; // 锁定初始目标
+		else
+		{
+			// 允许更新（NoUpdate=no）：缓存优先（只跟随锁定单位，防引擎集结目标点污染），
+			// 缓存空才回退引擎链；目标死亡后缓存冻结，回退锁定坐标
+			CoordStruct updated{};
+			bool gotUpdate = false;
+			if (!gotUpdate)
+			{
+				gotUpdate = GetTargetPosFromChain(updated, true);
+			}
+			if (gotUpdate)
+			{
+				_initialOriginPos = updated; // 跟随：更新锁定值
+				originPos = _initialOriginPos;
+			}
+			else
+				originPos = _initialOriginPos.IsEmpty() ? currentPos : _initialOriginPos; // 抛弃 update → 回退锁定坐标
+		}
+		break;
+	case VectorData::VectorOrigin::Launcher:
+		if (Data->OriginNoUpdate)
+			originPos = _initialOriginPos;
+		else
+		{
+			TrackOriginCoord(_pLauncher, false, _initialOriginPos); // 发射者活着：每帧快照；死亡：冻结
+			originPos = _initialOriginPos;
+		}
+		break;
+	case VectorData::VectorOrigin::Source:
+		if (Data->OriginNoUpdate)
+			originPos = _initialOriginPos;
+		else
+		{
+			TrackOriginCoord(_pSource, false, _initialOriginPos); // 来源活着：每帧快照；死亡：冻结
+			originPos = _initialOriginPos;
+		}
+		break;
+	case VectorData::VectorOrigin::Self:
+		originPos = Data->OriginNoUpdate ? _initialOriginPos : currentPos;
+		break;
+	}
+
+	// OriginFLH 偏移：对非 Self 模式生效
+	// AllowOriginTilt 时跳过二维 GetFLHAbsoluteCoords，后续用三维旋转处理
+	if (!Data->AllowOriginTilt)
+	{
+		if (!Data->OriginFLH.IsEmpty() && Data->Origin != VectorData::VectorOrigin::Self)
+			originPos = GetFLHAbsoluteCoords(originPos, Data->OriginFLH, mainFacingDir);
+	}
+
+// GetVectorResult：每帧计算位移（主体内联，段落化）
+
+	// ========================================================================
+	// 成熟机制，别乱动 — 模式 C: Circle（独立圆周，圆心=Origin，三选二参数）
+	// ========================================================================
+	bool hasCircle = Data->CircleRadius > 0 || Data->CircleAnglePerStep > 0.0
+		|| (Data->CircleRandomRadiusMax > Data->CircleRandomRadiusMin)
+		|| (Data->CircleRandomAngleMax > Data->CircleRandomAngleMin);
+	if (hasCircle)
+	{
+		// 三选二：缺半径用当前XY距离，缺速度用半径×角速度，缺角速度用速度/半径
+		double calcRadius = static_cast<double>(Data->CircleRadius);
+		if (calcRadius <= 0.0)
+		{
+			double tdx = currentPos.X - originPos.X;
+			double tdy = currentPos.Y - originPos.Y;
+			calcRadius = std::sqrt(tdx * tdx + tdy * tdy);
+		}
+		if (calcRadius < 1.0)
+			calcRadius = 1.0;  // 防止除零：半径 + 角速度互推时必 > 0
+
+		// 动态线速：每帧叠加加速度（初始值已在 DisabledFrames 前预初始化）
+		_motion.circleSpeed += Data->CircleSpeedAcceleration;
+		if (Data->CircleMaxSpeed != 0 && _motion.circleSpeed > Data->CircleMaxSpeed)
+			_motion.circleSpeed = static_cast<double>(Data->CircleMaxSpeed);
+		if (Data->CircleMinSpeed != 0 && _motion.circleSpeed < Data->CircleMinSpeed)
+			_motion.circleSpeed = static_cast<double>(Data->CircleMinSpeed);
+
+		// 角速度动态：每帧叠加加速度（初始值已在 DisabledFrames 前预初始化）
+		_motion.circleAngle += Data->CircleAngleAcceleration;
+		if (Data->CircleMaxAngle != 0.0 && _motion.circleAngle > Data->CircleMaxAngle)
+			_motion.circleAngle = Data->CircleMaxAngle;
+		if (Data->CircleMinAngle != 0.0 && _motion.circleAngle < Data->CircleMinAngle)
+			_motion.circleAngle = Data->CircleMinAngle;
+
+		double speed = _motion.circleSpeed;
+		double angleStep = _motion.circleAngle;
+
+		// 三选二：半径 + 角速度优先，两者都有时速率由角速度推算（忽略显式 CircleSpeed）
+		if (angleStep > 0.0)
+			speed = calcRadius * Math::deg2rad(angleStep);
+		else if (speed > 0.0)
+			angleStep = Math::rad2deg(speed / calcRadius);
+
+	// 圆心 = Origin + CircleOrigin 偏移（世界坐标系）
+	// CircleOrigin Z 高度规则：CircleOrigin 非空 → 绝对覆写 OriginFLH.Z+CircleOrigin.Z；
+	// 仅 OriginFLH 非空 → 相对偏移 _vectorAcquireZ+OriginFLH.Z
+	// 修改 CircleOrigin 的 Z 后再走 GetFLHAbsoluteCoords，tilt 对 F/L 分量的 Z 投影自动保留
+	CoordStruct adjustedCircleOrigin = Data->CircleOrigin;
+	if (!Data->CircleOrigin.IsEmpty())
+		adjustedCircleOrigin.Z = Data->OriginFLH.Z + Data->CircleOrigin.Z;
+
+	CoordStruct circleCenter = originPos;
+
+	// AllowOriginTilt：用三维 FLH 旋转替代二维 GetFLHAbsoluteCoords
+	if (Data->AllowOriginTilt && !Data->OriginFLH.IsEmpty() && Data->Origin != VectorData::VectorOrigin::Self)
+	{
+		int f = Data->OriginFLH.X, l = Data->OriginFLH.Y, h = Data->OriginFLH.Z;
+		double sinT = std::sin(originTerrainTilt), cosT = std::cos(originTerrainTilt);
+		// FLH 旋转用单位自身 facing（_facingRad 是法向量方向，不适用于 FLH 的 F/L 分量）
+		TechnoClass* pOriginTechno = nullptr;
+		switch (Data->Origin)
+		{
+		case VectorData::VectorOrigin::Target:
+			if (pBullet && pBullet->Target)
+				pOriginTechno = abstract_cast<TechnoClass*>(pBullet->Target);
+			else if (pTechno && pTechno->Target)
+				pOriginTechno = abstract_cast<TechnoClass*>(pTechno->Target);
+			break;
+		case VectorData::VectorOrigin::Source:
+			pOriginTechno = abstract_cast<TechnoClass*>(_pSource);
+			break;
+		case VectorData::VectorOrigin::Launcher:
+			pOriginTechno = abstract_cast<TechnoClass*>(_pLauncher);
+			break;
+		case VectorData::VectorOrigin::Self:
+			pOriginTechno = pTechno;
+			break;
+		}
+		double unitF = (pOriginTechno && !IsDeadOrInvisible(pOriginTechno))
+			? pOriginTechno->PrimaryFacing.Current().GetRadian() : 0.0;
+		double cosF = std::cos(unitF), sinF = std::sin(unitF);
+		// 先绕 L 轴（左右轴）转 tilt（俯仰），再绕 Z 轴转 facing
+		// tilt>0=头低屁股高，头部在 +F 方向偏下
+		// FLH=(f,l,h) 先 tilt: f'=f*cosT-h*sinT, l'=l, h'=f*sinT+h*cosT
+		// 再 facing: X=cosF*f'-sinF*l', Y=sinF*f'+cosF*l', Z=h'
+		double fTilt = f * cosT - h * sinT;
+		double hTilt = f * sinT + h * cosT;
+		circleCenter.X += static_cast<int>(fTilt * cosF - l * sinF);
+		circleCenter.Y += static_cast<int>(fTilt * sinF + l * cosF);
+		circleCenter.Z += static_cast<int>(hTilt);
+	}
+
+	if (!Data->CircleOrigin.IsEmpty())
+	{
+		if (Data->AllowOriginTilt)
+		{
+			// FLH→世界坐标（facing + terrainTilt 三维旋转），替换 GetFLHAbsoluteCoords（仅二维）
+			double cosF = std::cos(effectiveFacing), sinF = std::sin(effectiveFacing);
+			double cosT = std::cos(originTerrainTilt), sinT = std::sin(originTerrainTilt);
+			double f = static_cast<double>(adjustedCircleOrigin.X);
+			double l = static_cast<double>(adjustedCircleOrigin.Y);
+			double h = static_cast<double>(adjustedCircleOrigin.Z);
+			// 先绕 L 轴（左右轴）转 tilt（俯仰），再绕 Z 轴转 facing
+			double fTilt = f * cosT - h * sinT;
+			double hTilt = f * sinT + h * cosT;
+			circleCenter.X += static_cast<int>(fTilt * cosF - l * sinF);
+			circleCenter.Y += static_cast<int>(fTilt * sinF + l * cosF);
+			circleCenter.Z += static_cast<int>(hTilt);
+		}
+		else
+		{
+			circleCenter = originPos + adjustedCircleOrigin;
+		}
+	}
+	else if (!Data->OriginFLH.IsEmpty())
+	{
+		// 仅 OriginFLH：CircleOrigin 为空时不走 FLH 转换，手动设 Z
+		circleCenter.Z = _vectorAcquireZ + Data->OriginFLH.Z;
+	}
+
+		// 圆心移动：Vector.Origin.* 系统
+		if (!Data->OriginMoveTo.IsEmpty() || Data->OriginReachTarget || Data->OriginLinearSpeed >= 0 || !Data->OriginTargetFLH.IsEmpty()
+			|| Data->OriginCircleRadius >= 0 || Data->OriginCircleSpeed != 0 || Data->OriginCircleAnglePerStep != 0)
+		{
+			// 基座：默认 originPos，OriginOrigin 可替换为独立参考系
+			CoordStruct baseCenter = originPos;
+			if (Data->OriginOrigin != VectorData::VectorOrigin::Self)
+			{
+				switch (Data->OriginOrigin)
+				{
+				case VectorData::VectorOrigin::Launcher:
+					if (_pLauncher && !IsDeadOrInvisible(_pLauncher))
+					{
+						if (!Data->OriginOriginNoUpdate)
+							_initialBaseCenter = _pLauncher->GetCoords(); // 发射者活着：每帧快照（NoUpdate=yes 冻结首帧不更新）
+						baseCenter = _pLauncher->GetCoords();
+					}
+					else
+						baseCenter = _initialBaseCenter; // 发射者死亡：冻结快照（首帧或最后跟随值），不再读指针
+					break;
+				case VectorData::VectorOrigin::Target:
+					{
+						CoordStruct targetBase{};
+						bool gotTargetBase = false;
+						if (pTechno && pTechno->Target)
+						{
+							targetBase = pTechno->Target->GetCoords();
+							gotTargetBase = true;
+						}
+						else if (pTechno)
+						{
+							FootClass* pFoot = abstract_cast<FootClass*>(pTechno);
+							if (pFoot && pFoot->Destination)
+							{
+								targetBase = pFoot->Destination->GetCoords();
+								gotTargetBase = true;
+							}
+						}
+						else if (pBullet && pBullet->Target)
+						{
+							targetBase = pBullet->Target->GetCoords();
+							gotTargetBase = true;
+						}
+						else if (pBullet && pBullet->Owner && pBullet->Owner->Target)
+						{
+							targetBase = pBullet->Owner->Target->GetCoords();
+							gotTargetBase = true;
+						}
+						else if (pBullet)
+						{
+							targetBase = pBullet->TargetCoords;
+							gotTargetBase = true;
+						}
+						if (gotTargetBase)
+						{
+							if (!Data->OriginOriginNoUpdate)
+								_initialBaseCenter = targetBase; // 目标活着：每帧快照（NoUpdate=yes 冻结首帧不更新）
+							baseCenter = targetBase;
+						}
+						else
+							baseCenter = _initialBaseCenter; // 目标失效：冻结快照（首帧或最后跟随值），不再掉回 originPos
+					}
+					break;
+				case VectorData::VectorOrigin::Source:
+					if (_pSource && !IsDeadOrInvisible(_pSource))
+					{
+						if (!Data->OriginOriginNoUpdate)
+							_initialBaseCenter = _pSource->GetCoords(); // 来源活着：每帧快照（NoUpdate=yes 冻结首帧不更新）
+						baseCenter = _pSource->GetCoords();
+					}
+					else
+						baseCenter = _initialBaseCenter; // 来源死亡：冻结快照（首帧或最后跟随值），不再读指针
+					break;
+				}
+			}
+			else if (!Data->OriginOriginFLH.IsEmpty())
+			{
+				baseCenter.X += Data->OriginOriginFLH.X;
+				baseCenter.Y += Data->OriginOriginFLH.Y;
+				baseCenter.Z += Data->OriginOriginFLH.Z;
+			}
+
+			// Origin.CircleOffset 世界偏移
+			if (!Data->OriginCircleOffset.IsEmpty())
+				baseCenter = baseCenter + Data->OriginCircleOffset;
+
+			// OriginNoUpdate：首帧快照基座，后续帧冻结
+			if (_elapsedFrames == 0)
+				_initialBaseCenter = baseCenter;
+			else if (Data->OriginOriginNoUpdate)
+				baseCenter = _initialBaseCenter;
+
+			if (_elapsedFrames == 0)
+			{
+				// 初始偏移 = 圆心相对于基座的向量
+				_originOffset = circleCenter - baseCenter;
+				// Circle 初始化
+				_originMotion.circleRadius = Data->OriginCircleRadius;
+				_originMotion.circleSpeed = Data->OriginCircleSpeed;
+				_originMotion.angle = 0.0; // 初始相位
+				// 未显式设半径：取当前偏移的水平距离
+				if (_originMotion.circleRadius < 0)
+					_originMotion.circleRadius = (int)std::sqrt(
+						(double)_originOffset.X * _originOffset.X +
+						(double)_originOffset.Y * _originOffset.Y +
+						(double)_originOffset.Z * _originOffset.Z);
+				// 随机
+				if (Data->OriginCircleRandomRadiusMax > Data->OriginCircleRandomRadiusMin)
+					_originMotion.circleRadius = Random::RandomRanged(Data->OriginCircleRandomRadiusMin, Data->OriginCircleRandomRadiusMax);
+				if (Data->OriginCircleRandomAngleMax > Data->OriginCircleRandomAngleMin)
+					_originMotion.angle = Data->OriginCircleRandomAngleMin + (Data->OriginCircleRandomAngleMax - Data->OriginCircleRandomAngleMin) * Random::RandomDouble();
+				// Target 随机偏移
+				_originTargetOffset.X = Random::RandomRanged(Data->OriginTargetOffsetFMin, Data->OriginTargetOffsetFMax);
+				_originTargetOffset.Y = Random::RandomRanged(Data->OriginTargetOffsetLMin, Data->OriginTargetOffsetLMax);
+				_originTargetOffset.Z = Random::RandomRanged(Data->OriginTargetOffsetHMin, Data->OriginTargetOffsetHMax);
+				// Normal 初始化
+				if (!Data->OriginNormalVector.IsEmpty())
+				{
+					double fy = Data->OriginNormalVector.X, fx = Data->OriginNormalVector.Y, fz = Data->OriginNormalVector.Z;
+					if (Data->OriginNormalRandomF.Y > Data->OriginNormalRandomF.X) fy = Random::RandomRanged(Data->OriginNormalRandomF.X, Data->OriginNormalRandomF.Y);
+					if (Data->OriginNormalRandomL.Y > Data->OriginNormalRandomL.X) fx = Random::RandomRanged(Data->OriginNormalRandomL.X, Data->OriginNormalRandomL.Y);
+					if (Data->OriginNormalRandomH.Y > Data->OriginNormalRandomH.X) fz = Random::RandomRanged(Data->OriginNormalRandomH.X, Data->OriginNormalRandomH.Y);
+					double len = std::sqrt(fx*fx+fy*fy);
+					_originFacing = len>1e-6 ? std::atan2(fy,fx) : 0;
+					_originTilt = len>1e-6 ? std::atan2(fz,len) : (fz>0?M_PI/2.0:-M_PI/2.0);
+				}
+				// Normal 角速度
+				_originMotion.normalStepF = ResolveAngleStep(Data->OriginNormalFAnglePerStep, Data->OriginNormalFAngleRMin, Data->OriginNormalFAngleRMax, Data->OriginNormalFAngleRMin2, Data->OriginNormalFAngleRMax2);
+				_originMotion.normalStepL = ResolveAngleStep(Data->OriginNormalLAnglePerStep, Data->OriginNormalLAngleRMin, Data->OriginNormalLAngleRMax, Data->OriginNormalLAngleRMin2, Data->OriginNormalLAngleRMax2);
+				_originMotion.normalStepH = ResolveAngleStep(Data->OriginNormalHAnglePerStep, Data->OriginNormalHAngleRMin, Data->OriginNormalHAngleRMax, Data->OriginNormalHAngleRMin2, Data->OriginNormalHAngleRMax2);
+				_originMotion.lissajousStep = Data->OriginLissajous;
+				// 无 NormalVector 时：默认水平圆面（法向量朝上）
+				if (Data->OriginNormalVector.IsEmpty())
+				{
+					_originFacing = 0;
+					_originTilt = M_PI / 2.0;
+					// OriginAllowCircleTilt: 大圆面跟随目标倾斜（Origin=Target 时有效）
+					if (Data->OriginAllowCircleTilt && Data->OriginOrigin == VectorData::VectorOrigin::Target)
+					{
+						CoordStruct targetPos {};
+						bool hasTargetPos = false;
+						if (pBullet) { targetPos = pBullet->TargetCoords; hasTargetPos = true; }
+						else if (pTechno && pTechno->Target) { targetPos = pTechno->Target->GetCoords(); hasTargetPos = true; }
+						if (hasTargetPos)
+						{
+							double dx = circleCenter.X - targetPos.X;
+							double dy = circleCenter.Y - targetPos.Y;
+							double dz = circleCenter.Z - targetPos.Z;
+							double lenXY = std::sqrt(dx * dx + dy * dy);
+							_originTilt = (lenXY > 1e-6) ? std::atan2(dz, lenXY) : M_PI / 2.0;
+						}
+					}
+				}
+				else
+				{
+					switch (Data->OriginOrigin)
+					{
+					case VectorData::VectorOrigin::Launcher:
+						{
+							TechnoClass* pLT = abstract_cast<TechnoClass*>(_pLauncher);
+							if (pLT && !IsDeadOrInvisible(pLT))
+								_originFacing = pLT->TurretFacing().Current().GetRadian();
+							else if (pTechno) _originFacing = pTechno->TurretFacing().Current().GetRadian();
+						}
+						break;
+					case VectorData::VectorOrigin::Target:
+						if (pBullet) { auto tp = pBullet->TargetCoords; auto bp = pBullet->GetCoords(); _originFacing = std::atan2(bp.Y-tp.Y, bp.X-tp.X); }
+						else if (pTechno && pTechno->Target) { auto tp = pTechno->Target->GetCoords(); auto sp = pTechno->GetCoords(); _originFacing = std::atan2(sp.Y-tp.Y, sp.X-tp.X); }
+						break;
+					case VectorData::VectorOrigin::Source:
+						if (AE && AE->pSource) { auto sp = AE->pSource->GetCoords(); auto bp = pObject->GetCoords(); _originFacing = std::atan2(bp.Y-sp.Y, bp.X-sp.X); }
+						break;
+					default: // FLH
+						if (!Data->OriginOriginFLH.IsEmpty())
+						{
+							double fy = Data->OriginOriginFLH.X, fx = Data->OriginOriginFLH.Y;
+							_originFacing = std::atan2(fy, fx);
+						}
+						else if (pBullet) _originFacing = pBullet->Velocity.Magnitude() > 0 ? std::atan2(pBullet->Velocity.X, pBullet->Velocity.Y) : 0.0;
+						else if (pTechno) _originFacing = pTechno->TurretFacing().Current().GetRadian();
+						break;
+					}
+				}
+				// 初始化大圆 3D 法向量
+				{
+					double ct = std::cos(_originTilt), st = std::sin(_originTilt);
+					double cf = std::cos(_originFacing), sf = std::sin(_originFacing);
+					_originMotion.normalX = ct * cf;
+					_originMotion.normalY = ct * sf;
+					_originMotion.normalZ = st;
+				}
+			}
+		// 每帧累加 Lissajous + 3D 法向量增量旋转
+		_originMotion.normalRotF += _originMotion.lissajousStep;
+		if (_originMotion.normalStepF != 0.0 || _originMotion.normalStepL != 0.0 || _originMotion.normalStepH != 0.0)
+		{
+			RotateNormal3D(_originMotion.normalX, _originMotion.normalY, _originMotion.normalZ,
+				_originMotion.normalStepF, _originMotion.normalStepL, _originMotion.normalStepH);
+		}
+
+			// OriginAllowCircleTilt：每帧从目标 Z 差更新大圆面倾斜
+			if (Data->OriginAllowCircleTilt && Data->OriginOrigin == VectorData::VectorOrigin::Target)
+			{
+				CoordStruct oc = baseCenter + _originOffset;
+				CoordStruct targetPos {};
+				bool hasTargetPos = false;
+				if (pBullet) { targetPos = pBullet->TargetCoords; hasTargetPos = true; }
+				else if (pTechno && pTechno->Target) { targetPos = pTechno->Target->GetCoords(); hasTargetPos = true; }
+				if (hasTargetPos)
+				{
+					double dx = oc.X - targetPos.X, dy = oc.Y - targetPos.Y, dz = oc.Z - targetPos.Z;
+					double lenXY = std::sqrt(dx * dx + dy * dy);
+					_originTilt = (lenXY > 1e-6) ? std::atan2(dz, lenXY) : M_PI / 2.0;
+				}
+			}
+
+			double oFacing = _originFacing;
+			double oTilt = _originTilt + (Data->OriginAllowOriginTilt ? originTerrainTilt : 0.0);
+			// 3D 法向量旋转覆盖
+			if (_originMotion.normalStepF != 0.0 || _originMotion.normalStepL != 0.0 || _originMotion.normalStepH != 0.0)
+			{
+				double lenXY = std::sqrt(_originMotion.normalX * _originMotion.normalX + _originMotion.normalY * _originMotion.normalY);
+				oFacing = lenXY > 1e-6 ? std::atan2(_originMotion.normalY, _originMotion.normalX) : 0.0;
+				oTilt = lenXY > 1e-6 ? std::atan2(_originMotion.normalZ, lenXY) : (_originMotion.normalZ > 0 ? M_PI / 2.0 : -M_PI / 2.0);
+			}
+			DirStruct oFacingDir = Radians2Dir(oFacing); // 官方API，不得修改：弧度→DirStruct
+
+			// 当前圆心绝对位置 = 基座 + 偏移
+			CoordStruct originCenter = baseCenter + _originOffset;
+
+			CoordStruct disp;
+			if (!Data->OriginMoveTo.IsEmpty())
+			{
+				// MoveTo 模式：GrowRate 随帧数线性增长
+				_originMotion.angle += Data->OriginAnglePerStep;
+				CoordStruct growOffset;
+				growOffset = Data->OriginGrowRate * _originMotion.elapsed;
+				disp = GetFLHAbsoluteOffset(Data->OriginMoveTo + growOffset, Radians2Dir(oFacing + Math::deg2rad(_originMotion.angle))); // 官方API，不得修改
+			}
+			else if (Data->OriginReachTarget || Data->OriginLinearSpeed >= 0 || !Data->OriginTargetFLH.IsEmpty())
+			{
+				// Speed / ReachTarget
+				if (_originMotion.elapsed == 0)
+				{
+					_originMotion.speed = Data->OriginLinearSpeed >= 0 ? Data->OriginLinearSpeed : (pTechno ? pTechno->GetTechnoType()->Speed : 40.0);
+					_originMotion.arcStartCenter = originCenter;
+				}
+
+				CoordStruct targetWorld = GetFLHAbsoluteCoords(baseCenter, Data->OriginTargetFLH + _originTargetOffset, oFacingDir); // 官方API，不得修改
+				if (Data->OriginReachTarget)
+				{
+					int effectiveSteps = (AE->AEData.GetDuration() - Data->DisabledFrames) / _effectiveTimeStep;
+					if (effectiveSteps < 1) effectiveSteps = 1;
+					int rem = effectiveSteps - _movementFrames;
+					if (rem <= 0)
+					{
+						disp = targetWorld - originCenter;
+						_originOffset += disp;
+						circleCenter = baseCenter + _originOffset;
+						_prevCircleCenter = circleCenter;
+						Deactivate();
+						goto skipOriginUpdate;
+					}
+					disp.X = (targetWorld.X - originCenter.X) / rem;
+					disp.Y = (targetWorld.Y - originCenter.Y) / rem;
+					disp.Z = (targetWorld.Z - originCenter.Z) / rem;
+					if (_originMotion.arcHeight != 0)
+					{
+						double t = static_cast<double>(_movementFrames) / effectiveSteps;
+						double arcOffset = CalcArcOffsetAt(static_cast<int>(_originMotion.arcHeight), _originMotion.arcPeakPercent, t);
+						double baseX = _originMotion.arcStartCenter.X + (targetWorld.X - _originMotion.arcStartCenter.X) * t;
+						double baseY = _originMotion.arcStartCenter.Y + (targetWorld.Y - _originMotion.arcStartCenter.Y) * t;
+						double baseZ = _originMotion.arcStartCenter.Z + (targetWorld.Z - _originMotion.arcStartCenter.Z) * t;
+						if (_originMotion.arcRotation == 0.0)
+						{
+							disp.Z = static_cast<int>(baseZ + arcOffset) - originCenter.Z;
+						}
+						else
+						{
+							CoordStruct arcD{
+								targetWorld.X - _originMotion.arcStartCenter.X,
+								targetWorld.Y - _originMotion.arcStartCenter.Y,
+								targetWorld.Z - _originMotion.arcStartCenter.Z };
+							ArcDelta3D ad = RotateArcDelta(arcD, _originMotion.arcRotation, arcOffset);
+							disp.X = static_cast<int>(baseX + ad.x) - originCenter.X;
+							disp.Y = static_cast<int>(baseY + ad.y) - originCenter.Y;
+							disp.Z = static_cast<int>(baseZ + ad.z) - originCenter.Z;
+						}
+					}
+				}
+				else
+				{
+					_originMotion.speed += Data->OriginAcceleration;
+					if (Data->OriginMaxSpeed >= 0 && _originMotion.speed > Data->OriginMaxSpeed) _originMotion.speed = Data->OriginMaxSpeed;
+					if (Data->OriginMinSpeed >= 0 && _originMotion.speed < Data->OriginMinSpeed) _originMotion.speed = Data->OriginMinSpeed;
+					int dx = targetWorld.X - originCenter.X, dy = targetWorld.Y - originCenter.Y, dz = targetWorld.Z - originCenter.Z;
+					double dist = std::sqrt((double)dx*dx + dy*dy + dz*dz);
+					if (dist < 1.0) disp = {};
+					else if (Data->OriginSpeedEndOnReach && _originMotion.speed >= dist)
+					{
+						disp.X = dx; disp.Y = dy; disp.Z = dz;
+						Deactivate();
+					}
+					else { double s = _originMotion.speed / dist; disp.X = (int)(dx*s); disp.Y = (int)(dy*s); disp.Z = (int)(dz*s); }
+
+					// 弧高增量叠加（与 OriginReachTarget 一致，支持 ArcPeakPercent / ArcRotation）
+					if (_originMotion.arcHeight != 0 && dist >= 1.0)
+					{
+						if (_originMotion.arcTotalDist < 0.0)
+							_originMotion.arcTotalDist = dist;
+						double t = (_originMotion.arcTotalDist > 1e-6) ? 1.0 - dist / _originMotion.arcTotalDist : 0.0;
+						if (t < 0.0) t = 0.0; else if (t > 1.0) t = 1.0;
+						double arcThis = CalcArcOffsetAt(static_cast<int>(_originMotion.arcHeight), _originMotion.arcPeakPercent, t);
+						double arcDelta = arcThis - _originMotion.prevArcOffset;
+						_originMotion.prevArcOffset = arcThis;
+						CoordStruct arcD{
+							targetWorld.X - _originMotion.arcStartCenter.X,
+							targetWorld.Y - _originMotion.arcStartCenter.Y,
+							targetWorld.Z - _originMotion.arcStartCenter.Z };
+						ArcDelta3D ad = RotateArcDelta(arcD, _originMotion.arcRotation, arcDelta);
+						disp.X += static_cast<int>(ad.x);
+						disp.Y += static_cast<int>(ad.y);
+						disp.Z += static_cast<int>(ad.z);
+					}
+				}
+			}
+			else // Circle 模式
+			{
+				_originMotion.circleRadius += Data->OriginCircleRadiusGrow;
+				double tr = _originMotion.circleRadius;
+				if (Data->OriginCircleMaxRadius > 0 && tr > Data->OriginCircleMaxRadius) tr = Data->OriginCircleMaxRadius;
+				if (Data->OriginCircleMinRadius > 0 && tr < Data->OriginCircleMinRadius) tr = Data->OriginCircleMinRadius;
+				// 角步长：优先线速度/半径推算，否则用固定角速度
+				double originAngleStep = Data->OriginCircleAnglePerStep;
+				if (Data->OriginCircleSpeed != 0 && tr > 0)
+					originAngleStep = Math::rad2deg(Data->OriginCircleSpeed / tr);
+			// Lissajous>0: 累积大角旋转（增减边震荡），==0: 每帧仅增量旋转（平滑行星）
+			_originMotion.angle += originAngleStep;
+			double r = Data->OriginLissajous > 0.0 ? Math::deg2rad(_originMotion.angle + _originMotion.normalRotF) : Math::deg2rad(originAngleStep + _originMotion.normalRotF);
+				double ca = std::cos(r), sa = std::sin(r);
+				// 当前圆心相对基座的偏移在 LH 平面投影
+				double dx = (double)_originOffset.X, dy = (double)_originOffset.Y, dz = (double)_originOffset.Z;
+				double cf = std::cos(oFacing), sf = std::sin(oFacing), ct = std::cos(oTilt), st = std::sin(oTilt);
+				double dL = dx*(-sf) + dy*cf;
+				double dH = dx*(-cf*st) + dy*(-sf*st) + dz*ct;
+				double cd = std::sqrt(dL*dL + dH*dH);
+				// 圆心在基座上（偏移≈0），初始化到半径位置
+				if (cd < 1.0 && tr > 0)
+				{
+					dL = tr; dH = 0; cd = tr;
+				}
+				else if (cd < 1.0) cd = 1.0;
+				double rL = (dL/cd*tr*ca - dH/cd*tr*sa), rH = (dL/cd*tr*sa + dH/cd*tr*ca);
+				// 新偏移（世界坐标）
+				CoordStruct newOffset;
+				newOffset.X = (int)(rL*(-sf) + rH*(-cf*st));
+				newOffset.Y = (int)(rL*cf + rH*(-sf*st));
+				newOffset.Z = (int)(rH*ct);
+				disp.X = newOffset.X - _originOffset.X;
+				disp.Y = newOffset.Y - _originOffset.Y;
+				disp.Z = newOffset.Z - _originOffset.Z;
+			}
+	skipOriginUpdate:
+		_originOffset += disp;
+		circleCenter = baseCenter + _originOffset;
+		_originMotion.elapsed++;
+	}
+
+	// 圆心位移叠加：Circle 模式追踪圆心→调整 currentPos
+	CoordStruct centerDelta{ 0, 0, 0 };  // 初始化避免 C4701 警告
+	bool useCenterTracking = false;
+	if (_prevCircleCenter.X || _prevCircleCenter.Y || _prevCircleCenter.Z)
+	{
+		centerDelta = circleCenter - _prevCircleCenter;
+		if (Data->OriginLissajous <= 0.0 && (Data->OriginCircleRadius >= 0 || Data->OriginCircleSpeed != 0 || Data->OriginLinearSpeed >= 0 || Data->OriginCircleAnglePerStep != 0.0))
+			useCenterTracking = true;
+	}
+	_prevCircleCenter = circleCenter;
+
+	// 圆上目标基于内部跟踪位置（非 currentPos），避免与 MoveTo 等 AE 的位移打架
+	if (_circlePos.IsEmpty())
+		_circlePos = currentPos;
+	CoordStruct trackPos = _circlePos;
+	if (useCenterTracking)
+	{
+		trackPos.X += centerDelta.X;
+		trackPos.Y += centerDelta.Y;
+		trackPos.Z += centerDelta.Z;
+	}
+	double dx = static_cast<double>(trackPos.X - circleCenter.X);
+	double dy = static_cast<double>(trackPos.Y - circleCenter.Y);
+	double dz = static_cast<double>(trackPos.Z - circleCenter.Z);
+		double currentDist;
+		bool useTiltPlane = hasNormal || (Data->AllowCircleTilt && effectiveTilt != 0.0);
+		if (useTiltPlane)
+		{
+			// 倾斜圆面：投影到 LH 平面计算当前距离
+			double cosF = std::cos(effectiveFacing), sinF = std::sin(effectiveFacing);
+			double cosT = std::cos(effectiveTilt), sinT = std::sin(effectiveTilt);
+			double dL = dx * (-sinF) + dy * cosF;
+			double dH = dx * (-cosF * sinT) + dy * (-sinF * sinT) + dz * cosT;
+			currentDist = std::sqrt(dL * dL + dH * dH);
+		}
+		else
+		{
+			currentDist = std::sqrt(dx * dx + dy * dy);
+		}
+		if (currentDist < 1.0) currentDist = 1.0;
+
+		// 动态半径：首帧初始化，每帧叠加增长率
+		if (_elapsedFrames == 0)
+		{
+			_motion.circleRadius = static_cast<double>(Data->CircleRadius);
+			if (_motion.circleRadius <= 0.0)
+				_motion.circleRadius = currentDist;
+			if (Data->CircleRandomRadiusMax > Data->CircleRandomRadiusMin)
+				_motion.circleRadius = Random::RandomRanged(Data->CircleRandomRadiusMin, Data->CircleRandomRadiusMax);
+		}
+		_motion.circleRadius += Data->CircleRadiusGrow;
+
+		double targetRadius = _motion.circleRadius;
+		// 钳位
+		if (Data->CircleMaxRadius > 0 && targetRadius > Data->CircleMaxRadius)
+			targetRadius = static_cast<double>(Data->CircleMaxRadius);
+		if (Data->CircleMinRadius > 0 && targetRadius < Data->CircleMinRadius)
+			targetRadius = static_cast<double>(Data->CircleMinRadius);
+
+		double rad = Math::deg2rad(angleStep + _motion.normalRotF);
+		double cosA = std::cos(rad), sinA = std::sin(rad);
+
+		if (useTiltPlane)
+		{
+			// 倾斜圆面：在 LH 平面内旋转
+			double cosF = std::cos(effectiveFacing), sinF = std::sin(effectiveFacing);
+			double cosT = std::cos(effectiveTilt), sinT = std::sin(effectiveTilt);
+			double dL = dx * (-sinF) + dy * cosF;
+			double dH = dx * (-cosF * sinT) + dy * (-sinF * sinT) + dz * cosT;
+			double curDist = std::sqrt(dL * dL + dH * dH);
+			if (curDist < 1.0) curDist = 1.0;
+			double ndL = (dL / curDist * targetRadius);
+			double ndH = (dH / curDist * targetRadius);
+			double rL = ndL * cosA - ndH * sinA;
+			double rH = ndL * sinA + ndH * cosA;
+			result.MoveDisp.X = circleCenter.X + static_cast<int>(rL * (-sinF) + rH * (-cosF * sinT)) - _circlePos.X;
+			result.MoveDisp.Y = circleCenter.Y + static_cast<int>(rL * cosF + rH * (-sinF * sinT)) - _circlePos.Y;
+			result.MoveDisp.Z = circleCenter.Z + static_cast<int>(rH * cosT) - _circlePos.Z;
+		}
+		else
+		{
+			// 传统 2D 圆面（XY 平面）
+			double ndx = (dx / currentDist * targetRadius);
+			double ndy = (dy / currentDist * targetRadius);
+			double rx = ndx * cosA - ndy * sinA;
+			double ry = ndx * sinA + ndy * cosA;
+			result.MoveDisp.X = circleCenter.X + static_cast<int>(rx) - _circlePos.X;
+			result.MoveDisp.Y = circleCenter.Y + static_cast<int>(ry) - _circlePos.Y;
+			result.MoveDisp.Z = Data->CircleOrigin.IsEmpty() && Data->OriginFLH.IsEmpty()
+				? 0 : circleCenter.Z - _circlePos.Z;  // 有显式高度指定时拉 Z，否则维持抛射体自身高度
+		}
+		_circlePos.X += result.MoveDisp.X;
+		_circlePos.Y += result.MoveDisp.Y;
+		_circlePos.Z += result.MoveDisp.Z;
+		result.Force = true;
+
+		// 到达边界时结束 AE
+		if (Data->CircleEndOnMaxRadius && Data->CircleMaxRadius > 0
+			&& _motion.circleRadius >= Data->CircleMaxRadius)
+		{
+			Deactivate();
+		}
+		if (Data->CircleEndOnMinRadius && Data->CircleMinRadius > 0
+			&& _motion.circleRadius <= Data->CircleMinRadius)
+		{
+			Deactivate();
+		}
+
+		AdvanceFrame();
+		return result;
+	}
+
+	// ========================================================================
+	// 成熟机制，别乱动 — 模式 1: MoveTo（纯 FLH 位移 + GrowRate）
+	// ========================================================================
+	if (!Data->MoveTo.IsEmpty())
+	{
+		DirStruct moveDir = mainFacingDir;
+		double useCosT = 1.0, useSinT = 0.0;
+		bool hasTilt = (effectiveTilt != 0.0);
+
+		// Origin=Target：F 轴应以 抛射体→目标 连线为准（含 Z 落差），而非全局的 target→抛射体
+		if (Data->Origin == VectorData::VectorOrigin::Target)
+		{
+			CoordStruct tgt {};
+			bool hasTgt = false;
+			if (pBullet && pBullet->Target)
+				{ tgt = pBullet->Target->GetCoords(); hasTgt = true; }
+			else if (pBullet)
+				{ tgt = pBullet->TargetCoords; hasTgt = true; }
+			else if (pTechno && pTechno->Target)
+				{ tgt = pTechno->Target->GetCoords(); hasTgt = true; }
+			if (hasTgt)
+			{
+				double tdx = static_cast<double>(tgt.X - currentPos.X);
+				double tdy = static_cast<double>(tgt.Y - currentPos.Y);
+				double tdz = static_cast<double>(tgt.Z - currentPos.Z);
+				double tLenXY = std::sqrt(tdx * tdx + tdy * tdy);
+				if (tLenXY > 1e-6)
+				{
+					// 与 AutoWeapon IsOnTarget 同款：Point2Dir 内部处理 RA2 坐标系（裸 atan2+Radians2Dir 有 90° 偏置）
+					moveDir = Point2Dir(currentPos, tgt); // 抛射体→目标 连线方向
+					if (Data->AllowCircleTilt)
+					{
+						double tLen3D = std::sqrt(tdx * tdx + tdy * tdy + tdz * tdz);
+						useCosT = tLenXY / tLen3D;
+						useSinT = tdz / tLen3D;
+						hasTilt = true;
+					}
+				}
+			}
+		}
+
+		if (Data->AnglePerStep != 0.0)
+		{
+			if (_elapsedFrames == 0)
+				_motion.angle = 0.0;
+			_motion.angle += Data->AnglePerStep;
+			// SetRadian 与 GetRadian 互逆（Radians2Dir 往返存在 90° 偏置，不能用）
+			moveDir.SetRadian(moveDir.GetRadian() + Math::deg2rad(_motion.angle));
+		}
+
+		CoordStruct grow = { static_cast<int>(Data->GrowRate.X * _movementFrames),
+			static_cast<int>(Data->GrowRate.Y * _movementFrames),
+			static_cast<int>(Data->GrowRate.Z * _movementFrames) };
+		CoordStruct moveFlh = Data->MoveTo + grow;
+
+		if (hasTilt)
+		{
+			double mf = moveDir.GetRadian();
+			double cosF = std::cos(mf), sinF = std::sin(mf);
+			double cosT = (Data->Origin == VectorData::VectorOrigin::Target && Data->AllowCircleTilt)
+				? useCosT : std::cos(effectiveTilt);
+			double sinT = (Data->Origin == VectorData::VectorOrigin::Target && Data->AllowCircleTilt)
+				? useSinT : std::sin(effectiveTilt);
+			double F = static_cast<double>(moveFlh.X);
+			double L = static_cast<double>(moveFlh.Y);
+			double H = static_cast<double>(moveFlh.Z);
+			result.MoveDisp.X = static_cast<int>(F * cosF * cosT + L * (-sinF) + H * (-cosF * sinT));
+			result.MoveDisp.Y = static_cast<int>(F * sinF * cosT + L * cosF + H * (-sinF * sinT));
+			result.MoveDisp.Z = static_cast<int>(F * sinT + H * cosT);
+		}
+		else
+		{
+			result.MoveDisp = GetFLHAbsoluteOffset(moveFlh, moveDir); // 官方API，不得修改
+		}
+
+		result.Force = true;
+
+		AdvanceFrame();
+		return result;
+	}
+
+	// ========================================================================
+	// 以下为 TargetFLH 相关模式
+	// ========================================================================
+
+	// --- 目标世界坐标 ---
+	CoordStruct frameTargetFlh;
+	frameTargetFlh.X = Data->TargetFLH.X + _randomTargetOffset.X;
+	frameTargetFlh.Y = Data->TargetFLH.Y + _randomTargetOffset.Y;
+	frameTargetFlh.Z = Data->TargetFLH.Z + _randomTargetOffset.Z;
+
+	// TargetFLH → 世界坐标：AutoWeapon 同款管线
+	// 坐标系统一：矩阵偏移（含 IsOnTurret 炮塔/车身）+ NoUpdate 控制的计算点 originPos
+	CoordStruct frameTarget;
+	bool isOnTurret = !Data->OriginIsOnBody; // AutoWeapon 语义：yes=炮塔指向，no=车身指向
+	switch (Data->Origin)
+	{
+	case VectorData::VectorOrigin::Launcher:
+		{
+			TechnoClass* pLT = abstract_cast<TechnoClass*>(_pLauncher);
+			if (pLT && !IsDeadOrInvisible(pLT))
+			{
+				// AutoWeapon 同款：Locomotor 矩阵 + TurretOffset + 炮塔旋转角
+				CoordStruct mtxPos = GetFLHAbsoluteCoords(pLT, frameTargetFlh, isOnTurret);
+				frameTarget = originPos + (mtxPos - pLT->GetCoords());
+			}
+			else
+				frameTarget = GetFLHAbsoluteCoords(originPos, frameTargetFlh, mainFacingDir); // 官方API，不得修改
+		}
+		break;
+	case VectorData::VectorOrigin::Self:
+		if (Data->OriginIsOnWorld)
+			frameTarget = GetFLHAbsoluteCoords(originPos, frameTargetFlh, DirStruct{}); // 世界坐标系，无视倾斜
+		else if (pTechno)
+		{
+			// AutoWeapon 同款：Locomotor 矩阵 + TurretOffset + 炮塔旋转角
+			CoordStruct mtxPos = GetFLHAbsoluteCoords(pTechno, frameTargetFlh, isOnTurret);
+			frameTarget = originPos + (mtxPos - pTechno->GetCoords());
+		}
+		else
+			frameTarget = GetFLHAbsoluteCoords(originPos, frameTargetFlh, mainFacingDir); // 官方API，不得修改
+		break;
+	default: // Target / Source
+		frameTarget = GetFLHAbsoluteCoords(originPos, frameTargetFlh, mainFacingDir); // 官方API，不得修改
+		break;
+	}
+
+	CoordStruct dirVec;
+	dirVec.X = frameTarget.X - currentPos.X;
+	dirVec.Y = frameTarget.Y - currentPos.Y;
+	dirVec.Z = frameTarget.Z - currentPos.Z;
+	double dirLen = std::sqrt(static_cast<double>(dirVec.X * dirVec.X + dirVec.Y * dirVec.Y + dirVec.Z * dirVec.Z));
+
+	// 同步 Rocket loco 俯仰角：引擎自主移动姿态与 Vector 移动向量一致，
+	// 防止 Vector 结束后引擎按错误的 Pitch 继续飞行导致命中偏移（Spawn 导弹用 RocketLocomotionClass）
+	if (pTechno)
+	{
+		if (RocketLocomotionClass* rLoco = dynamic_cast<RocketLocomotionClass*>(
+			abstract_cast<FootClass*, true>(pTechno)->Locomotor.get()))
+		{
+			double lenXY = std::sqrt(static_cast<double>(dirVec.X * dirVec.X + dirVec.Y * dirVec.Y));
+			rLoco->CurrentPitch = static_cast<float>(std::atan2(dirVec.Z, lenXY));
+		}
+	}
+
+	CoordStruct resultDisp{ 0, 0, 0 };
+
+	// ========================================================================
+	// 成熟机制，别乱动 — 模式 2: ReachTarget（剩余帧数强制到达）
+	// ========================================================================
+	if (Data->ReachTarget && _totalDuration > 0)
+	{
+			int effectiveDuration = _totalDuration - Data->DisabledFrames;
+		if (effectiveDuration < 1) effectiveDuration = 1;
+		int remainingFrames = effectiveDuration - _movementFrames + 1;
+		if (Data->ReachTargetEarlyEnd > 0 && Data->ReachTargetEarlyEnd < effectiveDuration
+			&& remainingFrames <= Data->ReachTargetEarlyEnd)
+		{
+			Deactivate();
+			AdvanceFrame();
+			return result;
+		}
+		if (dirLen > 1e-6)
+		{
+			// AE 根基缺陷：Duration=N 实际只执行 N-1 个运动帧（末帧 AE 已移除）
+			// 轨迹按"实际帧数 = 总帧数 - 1"均分，保证 AE 实际删除的那一帧恰好到位
+			double adjustedSpeed = dirLen / (remainingFrames > 1 ? remainingFrames - 1 : 1);
+			resultDisp.X = static_cast<int>(dirVec.X / dirLen * adjustedSpeed);
+			resultDisp.Y = static_cast<int>(dirVec.Y / dirLen * adjustedSpeed);
+			resultDisp.Z = static_cast<int>(dirVec.Z / dirLen * adjustedSpeed);
+
+			// 抛物线弧高（Speed 模式影子算法：增量叠加，t 跟随实际路程，目标移动自动校准）
+			if (_motion.arcHeight != 0)
+			{
+				// 影子沿 frameTarget 方向推进 adjustedSpeed（与直线均分同步）
+				double ux = dirVec.X / dirLen, uy = dirVec.Y / dirLen, uz = dirVec.Z / dirLen;
+				_motion.shadowX += ux * adjustedSpeed;
+				_motion.shadowY += uy * adjustedSpeed;
+				_motion.shadowZ += uz * adjustedSpeed;
+				_motion.shadowTraveled += adjustedSpeed;
+
+				// 剩余影子距离（3D）
+				double sdx = frameTarget.X - _motion.shadowX;
+				double sdy = frameTarget.Y - _motion.shadowY;
+				double sdz = frameTarget.Z - _motion.shadowZ;
+				double shadowDist = std::sqrt(sdx * sdx + sdy * sdy + sdz * sdz);
+
+				// t = 已走路程 / 总路程（动态更新，目标移动时自动调整）
+				double total = _motion.shadowTraveled + shadowDist;
+				double t = (total > 1e-6) ? _motion.shadowTraveled / total : 0.0;
+				if (t < 0.0) t = 0.0; else if (t > 1.0) t = 1.0;
+
+				// 弧高增量叠加（不覆盖直线位移）
+				double arcOffset = CalcArcOffsetAt(t);
+				double arcDelta = arcOffset - _motion.prevArcOffset;
+				_motion.prevArcOffset = arcOffset;
+
+				CoordStruct arcD{
+					frameTarget.X - _initialLocation.X,
+					frameTarget.Y - _initialLocation.Y,
+					frameTarget.Z - _initialLocation.Z };
+				ArcDelta3D ad = RotateArcDelta(arcD, _motion.arcRotation, arcDelta);
+				resultDisp.X += static_cast<int>(ad.x);
+				resultDisp.Y += static_cast<int>(ad.y);
+				resultDisp.Z += static_cast<int>(ad.z);
+			}
+		}
+		result.MoveDisp = resultDisp;
+		AdvanceFrame();
+		return result;
+	}
+
+	// ========================================================================
+	// 模式5: Speed（直线追踪 + 加速度 + 影子坐标弧高）
+	// 影子沿 _shadowPos→frameTarget 方向推进，不受弧高Z偏移污染
+	// SpeedEndOnReach 和 t 均基于影子距离判定
+	// ========================================================================
+	if (Data->LinearSpeed >= 0)
+	{
+		double speed = _motion.speed;
+
+		// 加速度
+		if (Data->Acceleration != 0)
+		{
+			speed += Data->Acceleration * _elapsedFrames;
+		}
+
+		// 钳位
+		if (Data->MinSpeed >= 0 && speed < Data->MinSpeed)
+			speed = static_cast<double>(Data->MinSpeed);
+		if (Data->MaxSpeed >= 0 && speed > Data->MaxSpeed)
+			speed = static_cast<double>(Data->MaxSpeed);
+
+		// SpeedEndOnReach=yes/no 都走影子系统：弧线（影子坐标弧高）不依赖 SpeedEndOnReach；
+		// no 时不做到达瞬移，继续追踪直到引擎自然触地爆炸
+
+		// 以下：SpeedEndOnReach=yes，走影子系统
+		// 有弧线：影子追踪完整 3D，弧高增量叠加
+		double sdx = frameTarget.X - _motion.shadowX;
+		double sdy = frameTarget.Y - _motion.shadowY;
+		double sdz, shadowDist;
+		if (_motion.arcHeight != 0)
+		{
+			sdz = frameTarget.Z - _motion.shadowZ;
+			shadowDist = std::sqrt(sdx * sdx + sdy * sdy + sdz * sdz);
+		}
+		else
+		{
+			// 无弧线：仅 XY 距离，避免影子 Z 追踪目标导致 shadowDist 虚小
+			sdz = 0.0;
+			shadowDist = std::sqrt(sdx * sdx + sdy * sdy);
+		}
+
+		// SpeedEndOnReach：瞬移到目标位置，引擎正常到达检测会自然引爆（不手动Detonate，避免重复伤害）
+		// 到达判定用真实 3D 距离（含 Z），避免高空俯冲时 XY 先对齐导致误判到达
+		if (Data->SpeedEndOnReach)
+		{
+			double realDX = frameTarget.X - currentPos.X;
+			double realDY = frameTarget.Y - currentPos.Y;
+			double realDZ = frameTarget.Z - currentPos.Z;
+			double realDist = std::sqrt(realDX * realDX + realDY * realDY + realDZ * realDZ);
+			if (realDist <= speed)
+			{
+				// 强制挪移：到达帧直接把对象坐标设为目标格子坐标（完全重合），消除到位抖动
+				if (pBullet)
+				{
+					pBullet->SetLocation(frameTarget);
+					// 零位移：位置已由 SetLocation 设定，不再让 Vector.cpp 回退
+					result.MoveDisp = { 0, 0, 0 };
+					result.Force = false;
+				}
+				else if (pTechno)
+				{
+					// 强制挪移：直接 SetLocation 到目标格子坐标（含占位更新），不再经 MoveDisp 管线
+					bool onBridge = pTechno->OnBridge;
+					pTechno->UpdatePlacement(PlacementType::Remove);
+					pTechno->OnBridge = onBridge;
+					pTechno->SetLocation(frameTarget);
+					pTechno->UpdatePlacement(PlacementType::Put);
+					result.MoveDisp = { 0, 0, 0 };
+					result.Force = false;
+				}
+				Deactivate();
+				AdvanceFrame();
+				return result;
+			}
+		}
+
+		if (shadowDist > 1e-6)
+		{
+			// 影子沿 shadow→target 方向推进，步长钳位到剩余距离：
+			// 末段 speed > 剩余距离时若仍推进满 speed 会越过目标，sdx 变号导致来回振荡（原地抽搐）
+			double step = (speed < shadowDist) ? speed : shadowDist;
+			double sInv = 1.0 / shadowDist;
+			double shadowStepX = sdx * sInv * step;
+			double shadowStepY = sdy * sInv * step;
+			double shadowStepZ = 0.0;
+			_motion.shadowX += shadowStepX;
+			_motion.shadowY += shadowStepY;
+			if (_motion.arcHeight != 0)
+			{
+				shadowStepZ = sdz * sInv * step;
+				_motion.shadowZ += shadowStepZ;
+			}
+			// 无弧线：_shadowPosZ 不变（始终 = _initialLocation.Z），Z 由 t 插值
+			_motion.shadowTraveled += step;
+
+			// 重新计算影子距离（影子已移动）
+			sdx = frameTarget.X - _motion.shadowX;
+			sdy = frameTarget.Y - _motion.shadowY;
+			if (_motion.arcHeight != 0)
+			{
+				sdz = frameTarget.Z - _motion.shadowZ;
+				shadowDist = std::sqrt(sdx * sdx + sdy * sdy + sdz * sdz);
+			}
+			else
+			{
+				shadowDist = std::sqrt(sdx * sdx + sdy * sdy);
+			}
+
+			// t = 已走路程 / 总路程（动态更新，目标移动时自动调整）
+			double total = _motion.shadowTraveled + shadowDist;
+			double t = (total > 1e-6) ? _motion.shadowTraveled / total : 0.0;
+			if (t < 0.0) t = 0.0; else if (t > 1.0) t = 1.0;
+
+			// 实际位移：影子步长（XY）
+			resultDisp.X = static_cast<int>(shadowStepX);
+			resultDisp.Y = static_cast<int>(shadowStepY);
+
+			if (_motion.arcHeight != 0)
+			{
+				// 有弧线：Z 用影子增量 + 弧高增量叠加
+				resultDisp.Z = static_cast<int>(shadowStepZ);
+			}
+			else
+			{
+				// 无弧线：Z 从抛射体起始高度 lerp 到目标高度
+				// _shadowPosZ 在无弧线时冻结为抛射体起始 Z，_initialLocation.Z 可能是目标 Z（Origin=Target 时不同）
+				double targetZ = _motion.shadowZ + (frameTarget.Z - _motion.shadowZ) * t;
+				resultDisp.Z = static_cast<int>(targetZ - currentPos.Z);
+			}
+
+			if (_motion.arcHeight != 0)
+			{
+				double arcOffset = CalcArcOffsetAt(t);
+				double arcDelta = arcOffset - _motion.prevArcOffset;
+				_motion.prevArcOffset = arcOffset;
+
+				CoordStruct arcD{
+					frameTarget.X - _initialLocation.X,
+					frameTarget.Y - _initialLocation.Y,
+					frameTarget.Z - _initialLocation.Z };
+				ArcDelta3D ad = RotateArcDelta(arcD, _motion.arcRotation, arcDelta);
+				resultDisp.X += static_cast<int>(ad.x);
+				resultDisp.Y += static_cast<int>(ad.y);
+				resultDisp.Z += static_cast<int>(ad.z);
+			}
+		}
+		result.MoveDisp = resultDisp;
+		AdvanceFrame();
+		return result;
+	}
+
+	// 没命中任何模式，返回空
+	AdvanceFrame();
+	return result;
+}

--- a/src/Ext/EffectType/Effect/VectorEffectReVibed.cpp
+++ b/src/Ext/EffectType/Effect/VectorEffectReVibed.cpp
@@ -438,12 +438,42 @@ void VectorEffect::ParseTargetOffset()
 			{
 				flhAngle = Random::RandomDouble() * 2.0 * M_PI;  // 无角度限制：全向
 			}
-			_randomTargetOffset.X = static_cast<int>(radius * std::cos(flhAngle));
-			_randomTargetOffset.Y = static_cast<int>(radius * std::sin(flhAngle));
-			_randomTargetOffset.Z = (Data->TargetOffsetHMin2 < Data->TargetOffsetHMax2 && Random::RandomRanged(0, 1))
-				? Random::RandomRanged(Data->TargetOffsetHMin2, Data->TargetOffsetHMax2)
-				: (Data->TargetOffsetHMin < Data->TargetOffsetHMax
-					? Random::RandomRanged(Data->TargetOffsetHMin, Data->TargetOffsetHMax) : 0);
+			if (!Data->TargetOffsetNormal.IsEmpty())
+			{
+				// TargetOffsetNormal：随机落点在倾斜圆面上（法向量定义圆面），FLH 局部计算
+				// 法向量分量即 FLH（.X=F、.Y=L、.Z=H），落点也是 FLH 坐标（消费端 GetFLHAbsoluteCoords 旋转到世界）
+				// facing/tilt = 法线在 FL 平面的方位角 / 仰角（tilt=PI/2 法线朝上=水平圆环，与现有行为等价）
+				// 倾斜圆面取点：rL=radius*cos(flhAngle) 沿 L 切向、rH=radius*sin(flhAngle) 沿 H 方向，映射回 XYZ
+				// 注：flhAngle 的 0 度基准与水平圆环存在 90° 偏移（H 轴在法线朝上时指向 -F），全向随机时无影响
+				double fwX = static_cast<double>(Data->TargetOffsetNormal.Y); // L → X
+				double fwY = static_cast<double>(Data->TargetOffsetNormal.X); // F → Y
+				double fwZ = static_cast<double>(Data->TargetOffsetNormal.Z); // H → Z
+				double lenXY = std::sqrt(fwX * fwX + fwY * fwY);
+				double facing = lenXY > 1e-6 ? std::atan2(fwY, fwX) : 0.0;
+				double tilt = lenXY > 1e-6 ? std::atan2(fwZ, lenXY) : (fwZ > 0 ? M_PI / 2.0 : -M_PI / 2.0);
+				double cosF = std::cos(facing), sinF = std::sin(facing);
+				double cosT = std::cos(tilt), sinT = std::sin(tilt);
+				double rL = radius * std::cos(flhAngle);
+				double rH = radius * std::sin(flhAngle);
+				_randomTargetOffset.X = static_cast<int>(rL * (-sinF) + rH * (-cosF * sinT));
+				_randomTargetOffset.Y = static_cast<int>(rL * cosF + rH * (-sinF * sinT));
+				_randomTargetOffset.Z = static_cast<int>(rH * cosT);
+				// 选 B：倾斜面 Z 再叠加 TargetOffsetH 偏移（倾斜面 + 高度抖动）
+				if (Data->TargetOffsetHMin2 < Data->TargetOffsetHMax2 && Random::RandomRanged(0, 1))
+					_randomTargetOffset.Z += Random::RandomRanged(Data->TargetOffsetHMin2, Data->TargetOffsetHMax2);
+				else if (Data->TargetOffsetHMin < Data->TargetOffsetHMax)
+					_randomTargetOffset.Z += Random::RandomRanged(Data->TargetOffsetHMin, Data->TargetOffsetHMax);
+			}
+			else
+			{
+				// 原水平圆环：X/Y 在 FL 平面，Z 独立用 TargetOffsetH 随机
+				_randomTargetOffset.X = static_cast<int>(radius * std::cos(flhAngle));
+				_randomTargetOffset.Y = static_cast<int>(radius * std::sin(flhAngle));
+				_randomTargetOffset.Z = (Data->TargetOffsetHMin2 < Data->TargetOffsetHMax2 && Random::RandomRanged(0, 1))
+					? Random::RandomRanged(Data->TargetOffsetHMin2, Data->TargetOffsetHMax2)
+					: (Data->TargetOffsetHMin < Data->TargetOffsetHMax
+						? Random::RandomRanged(Data->TargetOffsetHMin, Data->TargetOffsetHMax) : 0);
+			}
 		}
 	}
 	else
@@ -664,6 +694,9 @@ void VectorEffect::LockFacing()
 			fwZ = Random::RandomRanged(Data->NormalRandomH.X, Data->NormalRandomH.Y);
 
 		double lenXY = std::sqrt(fwX * fwX + fwY * fwY);
+		// 法向量球坐标：facing = 法线在 XY 平面的方位角，tilt = 法线仰角（与水平面的夹角）
+		// 注意：tilt 是"仰角"不是"偏离垂直的角度"——tilt=PI/2 表示法线垂直向上（水平圆面），
+		// tilt=0 表示法线水平（侧立圆面）。与倾斜圆面取点数学（useTiltPlane 分支）的语义配套。
 		_facingRad = lenXY > 1e-6 ? std::atan2(fwY, fwX) : 0.0;
 		_tiltRad = lenXY > 1e-6 ? std::atan2(fwZ, lenXY) : (fwZ > 0 ? M_PI / 2.0 : -M_PI / 2.0);
 	}
@@ -680,6 +713,8 @@ void VectorEffect::LockFacing()
 
 	// 初始化 3D 法向量（从球坐标 _facingRad/_tiltRad 转换）
 	// 球坐标→笛卡尔：X=cos(tilt)cos(facing), Y=cos(tilt)sin(facing), Z=sin(tilt)
+	// _motion.normalX/Y/Z 是世界单位法向量（圆面法线方向）：
+	//   facing 影响法线在 XY 平面的指向，tilt 影响法线仰角（tilt=PI/2 → (0,0,1) 垂直向上）
 	{
 		double ct = std::cos(_tiltRad), st = std::sin(_tiltRad);
 		double cf = std::cos(_facingRad), sf = std::sin(_facingRad);
@@ -689,6 +724,8 @@ void VectorEffect::LockFacing()
 	}
 
 	// --- 非 Normal 的 Origin 朝向锁定 ---
+	// F 轴参考系来源：IsOnOrigin=yes 用 Origin 单位自身朝向，no 用 Origin→弹体连线
+	// （默认值按 Origin 类型推导：Launcher/Self→yes，Target/Source→no，见 VectorDataReVibed.h 解析处）
 	if (!hasNormal)
 	{
 		switch (Data->Origin)
@@ -698,7 +735,16 @@ void VectorEffect::LockFacing()
 			TechnoClass* pLauncherTechno = abstract_cast<TechnoClass*>(_pLauncher);
 			if (pLauncherTechno && !IsDeadOrInvisible(pLauncherTechno))
 			{
-				_facingDir = pLauncherTechno->TurretFacing().Current(); // 直接存 DirStruct，不经 GetRadian 往返
+				if (Data->IsOnOrigin)
+				{
+					_facingDir = Data->OriginIsOnBody
+						? pLauncherTechno->PrimaryFacing.Current()     // 官方API，不得修改
+						: pLauncherTechno->TurretFacing().Current();   // 官方API，不得修改
+				}
+				else
+				{
+					_facingDir = Point2Dir(pLauncherTechno->GetCoords(), pObject->GetCoords()); // 发射者→弹体连线
+				}
 				_facingRad = _facingDir.GetRadian();
 			}
 			break;
@@ -706,19 +752,36 @@ void VectorEffect::LockFacing()
 
 		case VectorData::VectorOrigin::Target:
 		{
-			// 射手角色 = 附着对象自身；F 轴 = Point2Dir(攻击目标, 弹体)。无攻击目标不锁定（保持默认朝向）
+			// F 轴：yes=目标单位自身朝向（目标无朝向/格子时回退连线），no=目标→弹体连线
+			CoordStruct targetPos{};
+			bool hasTarget = false;
 			if (pTechno && pTechno->Target)
 			{
-				CoordStruct targetPos = pTechno->Target->GetCoords();
-				CoordStruct sourcePos = pTechno->GetCoords(); // 射手角色 = 自身
-				_facingDir = Point2Dir(targetPos, sourcePos); // 官方API，不得修改
-				_facingRad = _facingDir.GetRadian();
+				targetPos = pTechno->Target->GetCoords();
+				hasTarget = true;
 			}
 			else if (pBullet)
 			{
-				CoordStruct bulletPos = pBullet->GetCoords();
-				CoordStruct targetPos = pBullet->TargetCoords;
-				_facingDir = Point2Dir(targetPos, bulletPos); // 官方API，不得修改
+				targetPos = pBullet->TargetCoords;
+				hasTarget = true;
+			}
+			if (hasTarget)
+			{
+				if (Data->IsOnOrigin)
+				{
+					AbstractClass* pTgt = pTechno ? pTechno->Target : (pBullet ? pBullet->Target : nullptr);
+					TechnoClass* pTargetTechno = abstract_cast<TechnoClass*>(pTgt);
+					if (pTargetTechno && !IsDeadOrInvisible(pTargetTechno))
+					{
+						_facingDir = Data->OriginIsOnBody
+							? pTargetTechno->PrimaryFacing.Current()     // 官方API，不得修改
+							: pTargetTechno->TurretFacing().Current();   // 官方API，不得修改
+						_facingRad = _facingDir.GetRadian();
+						break;
+					}
+					// 目标无朝向（格子）：回退连线
+				}
+				_facingDir = Point2Dir(targetPos, pObject->GetCoords()); // 官方API，不得修改：目标→弹体连线
 				_facingRad = _facingDir.GetRadian();
 			}
 			break;
@@ -726,21 +789,30 @@ void VectorEffect::LockFacing()
 
 		case VectorData::VectorOrigin::Source:
 		{
-			// 与 Target 模式对齐：F 轴 = Origin(Source) → 弹体 方向（每帧 no 路径同向，NoUpdate 切换不再镜像）
-			if (pBullet && AE && AE->pSource)
+			// F 轴：yes=Source 单位自身朝向（无朝向回退连线），no=Source→弹体连线
+			if (AE && AE->pSource)
 			{
-				_facingDir = Point2Dir(AE->pSource->GetCoords(), pBullet->GetCoords()); // 官方API
-				_facingRad = _facingDir.GetRadian();
-			}
-			else if (pTechno && AE && AE->pSource)
-			{
-				_facingDir = Point2Dir(AE->pSource->GetCoords(), pTechno->GetCoords()); // 官方API
+				CoordStruct sourcePos = AE->pSource->GetCoords();
+				if (Data->IsOnOrigin)
+				{
+					TechnoClass* pSourceTechno = abstract_cast<TechnoClass*>(AE->pSource);
+					if (pSourceTechno && !IsDeadOrInvisible(pSourceTechno))
+					{
+						_facingDir = Data->OriginIsOnBody
+							? pSourceTechno->PrimaryFacing.Current()     // 官方API，不得修改
+							: pSourceTechno->TurretFacing().Current();   // 官方API，不得修改
+						_facingRad = _facingDir.GetRadian();
+						break;
+					}
+					// 来源无朝向：回退连线
+				}
+				_facingDir = Point2Dir(sourcePos, pObject->GetCoords()); // 官方API：Source→弹体连线
 				_facingRad = _facingDir.GetRadian();
 			}
 			break;
 		}
 
-		default: // FLH：抛射体自身朝向
+		default: // FLH：抛射体自身朝向（Self 无"另一单位朝向"，IsOnOrigin 不区分）
 		{
 			if (pBullet)
 				_facingRad = std::atan2(pBullet->Velocity.X, pBullet->Velocity.Y);
@@ -749,6 +821,14 @@ void VectorEffect::LockFacing()
 			break;
 		}
 		}
+	}
+
+	// TargetOffsetNormal 世界固定（IsNormalOnOrigin=no）：把 FLH 落点按锁定朝向转成世界坐标，
+	// 消费端把偏移叠加在旋转后的 TargetFLH 上，不随 F 轴（单位朝向）转动。
+	// 注：hasNormal 时 _facingDir 未锁定（默认朝向），该组合的世界固定基准按实测调整。
+	if (!Data->IsNormalOnOrigin && !Data->TargetOffsetNormal.IsEmpty())
+	{
+		_randomTargetOffset = GetFLHAbsoluteCoords(CoordStruct::Empty, _randomTargetOffset, _facingDir); // 官方API
 	}
 }
 
@@ -986,6 +1066,7 @@ VectorResult VectorEffect::GetVectorResult()
 	}
 
 	// 统一朝向算法：NoUpdate 只切换计算点（锁定 _initialOriginPos vs 实时坐标），不切换坐标系/朝向算法
+	// F 轴来源：IsOnOrigin=yes 用 Origin 单位自身朝向，no 用 Origin→弹体连线（默认值按 Origin 类型推导）
 	if (!hasNormal && !Data->AllowOriginTilt && !Data->OriginIsOnWorld)
 	{
 		switch (Data->Origin)
@@ -995,6 +1076,19 @@ VectorResult VectorEffect::GetVectorResult()
 			TrackOriginCoord(_pSource, Data->OriginNoUpdate, _initialOriginPos);
 			if (!_initialOriginPos.IsEmpty())
 			{
+				if (Data->IsOnOrigin)
+				{
+					TechnoClass* pSourceTechno = abstract_cast<TechnoClass*>(_pSource);
+					if (pSourceTechno && !IsDeadOrInvisible(pSourceTechno))
+					{
+						mainFacingDir = Data->OriginIsOnBody
+							? pSourceTechno->PrimaryFacing.Current()     // 官方API，不得修改
+							: pSourceTechno->TurretFacing().Current();   // 官方API，不得修改
+						effectiveFacing = mainFacingDir.GetRadian();
+						break;
+					}
+					// 来源无朝向：回退连线
+				}
 				// 来源活着或已死亡：都用快照算朝向（死亡后冻结指向死亡点）
 				mainFacingDir = Point2Dir(_initialOriginPos, currentPos); // 官方API，不得修改
 				effectiveFacing = mainFacingDir.GetRadian();
@@ -1021,6 +1115,20 @@ VectorResult VectorEffect::GetVectorResult()
 				_initialOriginPos = targetPos; // 跟随：更新锁定值
 			else if (targetPos.IsEmpty())
 				break; // 从未有过目标：保持朝向
+			if (Data->IsOnOrigin)
+			{
+				AbstractClass* pTgt = pBullet ? pBullet->Target : (pTechno ? pTechno->Target : nullptr);
+				TechnoClass* pTargetTechno = abstract_cast<TechnoClass*>(pTgt);
+				if (pTargetTechno && !IsDeadOrInvisible(pTargetTechno))
+				{
+					mainFacingDir = Data->OriginIsOnBody
+						? pTargetTechno->PrimaryFacing.Current()     // 官方API，不得修改
+						: pTargetTechno->TurretFacing().Current();   // 官方API，不得修改
+					effectiveFacing = mainFacingDir.GetRadian();
+					break;
+				}
+				// 目标无朝向（格子）：回退连线
+			}
 			mainFacingDir = Point2Dir(targetPos, currentPos); // 官方API，不得修改
 			effectiveFacing = mainFacingDir.GetRadian();
 			double dx = currentPos.X - targetPos.X, dy = currentPos.Y - targetPos.Y, dz = currentPos.Z - targetPos.Z;
@@ -1050,14 +1158,67 @@ VectorResult VectorEffect::GetVectorResult()
 				TechnoClass* pLauncherTechno = abstract_cast<TechnoClass*>(_pLauncher);
 				if (pLauncherTechno)
 				{
-					mainFacingDir = Data->OriginIsOnBody
-						? pLauncherTechno->PrimaryFacing.Current()     // 官方API，不得修改
-						: pLauncherTechno->TurretFacing().Current();   // 官方API，不得修改
-					effectiveFacing = mainFacingDir.GetRadian();
+					if (Data->IsOnOrigin)
+					{
+						mainFacingDir = Data->OriginIsOnBody
+							? pLauncherTechno->PrimaryFacing.Current()     // 官方API，不得修改
+							: pLauncherTechno->TurretFacing().Current();   // 官方API，不得修改
+						effectiveFacing = mainFacingDir.GetRadian();
+					}
+					else
+					{
+						// 发射者→弹体连线
+						mainFacingDir = Point2Dir(pLauncherTechno->GetCoords(), currentPos); // 官方API，不得修改
+						effectiveFacing = mainFacingDir.GetRadian();
+					}
 				}
 			}
 			break;
 		}
+	}
+
+	// IsNormalOnOrigin：圆面法向量水平朝向（facing）每帧跟随 Origin 单位自身朝向（单位旋转带动圆面转动），
+	// 仰角：有 NormalVector 用它的仰角（_tiltRad），无则默认水平圆面（PI/2）。
+	// no（显式）= 世界固定，法向量由 LockFacing 初始化后不在此刷新。
+	// yes 时同时覆盖 effectiveFacing，使倾斜圆面数学（useTiltPlane 分支）与法向量一致跟随单位朝向。
+	if (Data->IsNormalOnOrigin && !Data->OriginIsOnWorld)
+	{
+		double facing = effectiveFacing;
+		switch (Data->Origin)
+		{
+		case VectorData::VectorOrigin::Launcher:
+			{
+				TechnoClass* pLT = abstract_cast<TechnoClass*>(_pLauncher);
+				if (pLT && !IsDeadOrInvisible(pLT))
+					facing = (Data->OriginIsOnBody ? pLT->PrimaryFacing.Current() : pLT->TurretFacing().Current()).GetRadian(); // 官方API，不得修改
+			}
+			break;
+		case VectorData::VectorOrigin::Target:
+			{
+				AbstractClass* pTgt = pBullet ? pBullet->Target : (pTechno ? pTechno->Target : nullptr);
+				TechnoClass* pTT = abstract_cast<TechnoClass*>(pTgt);
+				if (pTT && !IsDeadOrInvisible(pTT))
+					facing = (Data->OriginIsOnBody ? pTT->PrimaryFacing.Current() : pTT->TurretFacing().Current()).GetRadian(); // 官方API，不得修改
+				// 目标无朝向（格子）：保持 effectiveFacing（连线）
+			}
+			break;
+		case VectorData::VectorOrigin::Source:
+			{
+				TechnoClass* pST = abstract_cast<TechnoClass*>(_pSource);
+				if (pST && !IsDeadOrInvisible(pST))
+					facing = (Data->OriginIsOnBody ? pST->PrimaryFacing.Current() : pST->TurretFacing().Current()).GetRadian(); // 官方API，不得修改
+			}
+			break;
+		default: // Self：自身朝向即 effectiveFacing，无需覆盖
+			break;
+		}
+		double tilt = hasNormal ? _tiltRad : M_PI / 2.0;
+		double ct = std::cos(tilt), st = std::sin(tilt);
+		double cf = std::cos(facing), sf = std::sin(facing);
+		_motion.normalX = ct * cf;
+		_motion.normalY = ct * sf;
+		_motion.normalZ = st;
+		effectiveFacing = facing;
 	}
 
 	// 3D 法向量旋转覆盖：当 NormalF/L/HAnglePerStep 设定时，无视基座变化
@@ -1381,7 +1542,7 @@ VectorResult VectorEffect::GetVectorResult()
 				_originMotion.normalStepL = ResolveAngleStep(Data->OriginNormalLAnglePerStep, Data->OriginNormalLAngleRMin, Data->OriginNormalLAngleRMax, Data->OriginNormalLAngleRMin2, Data->OriginNormalLAngleRMax2);
 				_originMotion.normalStepH = ResolveAngleStep(Data->OriginNormalHAnglePerStep, Data->OriginNormalHAngleRMin, Data->OriginNormalHAngleRMax, Data->OriginNormalHAngleRMin2, Data->OriginNormalHAngleRMax2);
 				_originMotion.lissajousStep = Data->OriginLissajous;
-				// 无 NormalVector 时：默认水平圆面（法向量朝上）
+				// 无 OriginNormalVector 时：默认水平圆面（法向量朝上）
 				if (Data->OriginNormalVector.IsEmpty())
 				{
 					_originFacing = 0;
@@ -1403,36 +1564,8 @@ VectorResult VectorEffect::GetVectorResult()
 						}
 					}
 				}
-				else
-				{
-					switch (Data->OriginOrigin)
-					{
-					case VectorData::VectorOrigin::Launcher:
-						{
-							TechnoClass* pLT = abstract_cast<TechnoClass*>(_pLauncher);
-							if (pLT && !IsDeadOrInvisible(pLT))
-								_originFacing = pLT->TurretFacing().Current().GetRadian();
-							else if (pTechno) _originFacing = pTechno->TurretFacing().Current().GetRadian();
-						}
-						break;
-					case VectorData::VectorOrigin::Target:
-						if (pBullet) { auto tp = pBullet->TargetCoords; auto bp = pBullet->GetCoords(); _originFacing = std::atan2(bp.Y-tp.Y, bp.X-tp.X); }
-						else if (pTechno && pTechno->Target) { auto tp = pTechno->Target->GetCoords(); auto sp = pTechno->GetCoords(); _originFacing = std::atan2(sp.Y-tp.Y, sp.X-tp.X); }
-						break;
-					case VectorData::VectorOrigin::Source:
-						if (AE && AE->pSource) { auto sp = AE->pSource->GetCoords(); auto bp = pObject->GetCoords(); _originFacing = std::atan2(bp.Y-sp.Y, bp.X-sp.X); }
-						break;
-					default: // FLH
-						if (!Data->OriginOriginFLH.IsEmpty())
-						{
-							double fy = Data->OriginOriginFLH.X, fx = Data->OriginOriginFLH.Y;
-							_originFacing = std::atan2(fy, fx);
-						}
-						else if (pBullet) _originFacing = pBullet->Velocity.Magnitude() > 0 ? std::atan2(pBullet->Velocity.X, pBullet->Velocity.Y) : 0.0;
-						else if (pTechno) _originFacing = pTechno->TurretFacing().Current().GetRadian();
-						break;
-					}
-				}
+				// 有 OriginNormalVector 时：facing/tilt 均取它的 F/L/H 分量（彻底世界固定）。
+				// IsNormalOnOrigin=yes 时的 OriginOrigin 朝向跟随在下方每帧段处理。
 				// 初始化大圆 3D 法向量
 				{
 					double ct = std::cos(_originTilt), st = std::sin(_originTilt);
@@ -1442,6 +1575,56 @@ VectorResult VectorEffect::GetVectorResult()
 					_originMotion.normalZ = st;
 				}
 			}
+		// OriginIsNormalOnOrigin：大圆法向量水平朝向（facing）每帧跟随 OriginOrigin 单位自身朝向，
+		// 仰角保持首帧初始值（_originTilt）。no（显式）= 彻底世界固定，facing 取 OriginNormalVector
+		// 的 F/L 分量（首帧已定），不做处理。
+		if (Data->OriginIsNormalOnOrigin && !Data->OriginNormalVector.IsEmpty())
+		{
+			double facing = _originFacing;
+			switch (Data->OriginOrigin)
+			{
+			case VectorData::VectorOrigin::Launcher:
+				{
+					TechnoClass* pLT = abstract_cast<TechnoClass*>(_pLauncher);
+					if (pLT && !IsDeadOrInvisible(pLT))
+						facing = pLT->TurretFacing().Current().GetRadian(); // 官方API，不得修改
+					else if (pTechno) facing = pTechno->TurretFacing().Current().GetRadian(); // 官方API，不得修改
+				}
+				break;
+			case VectorData::VectorOrigin::Target:
+				{
+					AbstractClass* pTgt = pBullet ? pBullet->Target : (pTechno ? pTechno->Target : nullptr);
+					TechnoClass* pTT = abstract_cast<TechnoClass*>(pTgt);
+					if (pTT && !IsDeadOrInvisible(pTT))
+						facing = pTT->TurretFacing().Current().GetRadian(); // 官方API，不得修改
+					else if (pBullet) { auto tp = pBullet->TargetCoords; auto bp = pBullet->GetCoords(); facing = std::atan2(bp.Y-tp.Y, bp.X-tp.X); } // 格子：回退连线
+					else if (pTechno && pTechno->Target) { auto tp = pTechno->Target->GetCoords(); auto sp = pTechno->GetCoords(); facing = std::atan2(sp.Y-tp.Y, sp.X-tp.X); }
+				}
+				break;
+			case VectorData::VectorOrigin::Source:
+				{
+					TechnoClass* pST = abstract_cast<TechnoClass*>(AE && AE->pSource ? AE->pSource : nullptr);
+					if (pST && !IsDeadOrInvisible(pST))
+						facing = pST->TurretFacing().Current().GetRadian(); // 官方API，不得修改
+					else if (AE && AE->pSource) { auto sp = AE->pSource->GetCoords(); auto bp = pObject->GetCoords(); facing = std::atan2(bp.Y-sp.Y, bp.X-sp.X); } // 非单位：回退连线
+				}
+				break;
+			default: // FLH
+				if (!Data->OriginOriginFLH.IsEmpty())
+				{
+					double fy = Data->OriginOriginFLH.X, fx = Data->OriginOriginFLH.Y;
+					facing = std::atan2(fy, fx);
+				}
+				else if (pBullet) facing = pBullet->Velocity.Magnitude() > 0 ? std::atan2(pBullet->Velocity.X, pBullet->Velocity.Y) : 0.0;
+				else if (pTechno) facing = pTechno->TurretFacing().Current().GetRadian(); // 官方API，不得修改
+				break;
+			}
+			double ct = std::cos(_originTilt), st = std::sin(_originTilt);
+			double cf = std::cos(facing), sf = std::sin(facing);
+			_originMotion.normalX = ct * cf;
+			_originMotion.normalY = ct * sf;
+			_originMotion.normalZ = st;
+		}
 		// 每帧累加 Lissajous + 3D 法向量增量旋转
 		_originMotion.normalRotF += _originMotion.lissajousStep;
 		if (_originMotion.normalStepF != 0.0 || _originMotion.normalStepL != 0.0 || _originMotion.normalStepH != 0.0)
@@ -1646,7 +1829,13 @@ VectorResult VectorEffect::GetVectorResult()
 		bool useTiltPlane = hasNormal || (Data->AllowCircleTilt && effectiveTilt != 0.0);
 		if (useTiltPlane)
 		{
-			// 倾斜圆面：投影到 LH 平面计算当前距离
+			// 倾斜圆面：把世界向量投影到圆面局部 LH 平面（L=水平切向，H=圆面"上"方向）
+			// 圆面局部正交基（由法线球坐标 facing/tilt 构造）：
+			//   L 轴 = (-sinF, cosF, 0)                       （水平切向）
+			//   H 轴 = (-cosF*sinT, -sinF*sinT, cosT)          （圆面"上"）
+			//   法线 = L×H = (cosF*cosT, sinF*cosT, sinT)      （tilt=法线仰角）
+			// 语义验证：tilt=PI/2 → 法线 (0,0,1) 垂直向上 → 圆面水平（Z 恒定，落在 XY 平面）；
+			//          tilt=0   → 法线水平 → 圆面侧立（Z 由 H 分量独立决定）
 			double cosF = std::cos(effectiveFacing), sinF = std::sin(effectiveFacing);
 			double cosT = std::cos(effectiveTilt), sinT = std::sin(effectiveTilt);
 			double dL = dx * (-sinF) + dy * cosF;
@@ -1682,7 +1871,11 @@ VectorResult VectorEffect::GetVectorResult()
 
 		if (useTiltPlane)
 		{
-			// 倾斜圆面：在 LH 平面内旋转
+			// 倾斜圆面取点（与上方投影同一套正交基，见 useTiltPlane 距离投影处注释）：
+			//   1. 世界 → LH 平面投影（dL/dH）
+			//   2. 在 LH 平面内旋转角度 A（rL = ndL*cosA - ndH*sinA, rH = ndL*sinA + ndH*cosA）
+			//   3. LH → 世界 回映射：X = rL*L.x + rH*H.x, Y = rL*L.y + rH*H.y, Z = rH*H.z
+			// 即落点 = 圆心 + rL*L轴 + rH*H轴，保证始终落在法线 (cosF*cosT, sinF*cosT, sinT) 定义的圆面上
 			double cosF = std::cos(effectiveFacing), sinF = std::sin(effectiveFacing);
 			double cosT = std::cos(effectiveTilt), sinT = std::sin(effectiveTilt);
 			double dL = dx * (-sinF) + dy * cosF;
@@ -1817,9 +2010,11 @@ VectorResult VectorEffect::GetVectorResult()
 
 	// --- 目标世界坐标 ---
 	CoordStruct frameTargetFlh;
-	frameTargetFlh.X = Data->TargetFLH.X + _randomTargetOffset.X;
-	frameTargetFlh.Y = Data->TargetFLH.Y + _randomTargetOffset.Y;
-	frameTargetFlh.Z = Data->TargetFLH.Z + _randomTargetOffset.Z;
+	// TargetOffsetNormal 世界固定：偏移已由 LockFacing 转成世界坐标，叠加在旋转后的 TargetFLH 上（不随 F 轴转）
+	bool targetOffsetWorld = !Data->IsNormalOnOrigin && !Data->TargetOffsetNormal.IsEmpty();
+	frameTargetFlh.X = Data->TargetFLH.X + (targetOffsetWorld ? 0 : _randomTargetOffset.X);
+	frameTargetFlh.Y = Data->TargetFLH.Y + (targetOffsetWorld ? 0 : _randomTargetOffset.Y);
+	frameTargetFlh.Z = Data->TargetFLH.Z + (targetOffsetWorld ? 0 : _randomTargetOffset.Z);
 
 	// TargetFLH → 世界坐标：AutoWeapon 同款管线
 	// 坐标系统一：矩阵偏移（含 IsOnTurret 炮塔/车身）+ NoUpdate 控制的计算点 originPos
@@ -1832,8 +2027,10 @@ VectorResult VectorEffect::GetVectorResult()
 			TechnoClass* pLT = abstract_cast<TechnoClass*>(_pLauncher);
 			if (pLT && !IsDeadOrInvisible(pLT))
 			{
-				// AutoWeapon 同款：Locomotor 矩阵 + TurretOffset + 炮塔旋转角
-				CoordStruct mtxPos = GetFLHAbsoluteCoords(pLT, frameTargetFlh, isOnTurret);
+			// 已知不一致（用户决定不修）：OriginIsOnWorld=yes 时此路径仍用发射者炮塔矩阵旋转 FLH，
+			// 没有完全"无视单位朝向"（Self 分支有 OriginIsOnWorld 判断，Launcher 没有）。
+			// 实际中 OriginIsOnWorld + Origin=Launcher 组合过于怪异，不做处理。
+			CoordStruct mtxPos = GetFLHAbsoluteCoords(pLT, frameTargetFlh, isOnTurret);
 				frameTarget = originPos + (mtxPos - pLT->GetCoords());
 			}
 			else
@@ -1855,6 +2052,14 @@ VectorResult VectorEffect::GetVectorResult()
 	default: // Target / Source
 		frameTarget = GetFLHAbsoluteCoords(originPos, frameTargetFlh, mainFacingDir); // 官方API，不得修改
 		break;
+	}
+
+	// TargetOffsetNormal 世界固定：偏移（世界坐标）叠加在旋转后的 TargetFLH 上，不随 F 轴转
+	if (targetOffsetWorld)
+	{
+		frameTarget.X += _randomTargetOffset.X;
+		frameTarget.Y += _randomTargetOffset.Y;
+		frameTarget.Z += _randomTargetOffset.Z;
 	}
 
 	CoordStruct dirVec;

--- a/src/Ext/EffectType/Effect/VectorEffectReVibed.h
+++ b/src/Ext/EffectType/Effect/VectorEffectReVibed.h
@@ -1,0 +1,288 @@
+#pragma once
+// ============================================================================
+// VectorReVibed — 逻辑层（从零重写版）
+//
+// 文件名带 ReVibed 后缀与旧版（VectorEffect.h）隔离；类名保持 VectorEffect，
+// 注册键/INI 前缀与旧版完全一致，替换时仅切换 include 路径与 vcxproj。
+//
+// 设计目标（见 .workbuddy/notes/Vector重构操作计划.md）：
+//   1. 编排层 + 子函数：OnStart/GetVectorResult 只做时序编排，计算全部拆出
+//   2. 主/大圆共用 MotionState + 数据驱动 StepMotion，消灭成对状态变量
+//   3. 公共数学函数：弧旋转/法向量旋转/三态跟踪/Target 链 全部归一
+//   4. 行为等价铁律：数学公式逐字照搬旧版，不改任何 INI 语义
+// ============================================================================
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include <GeneralDefinitions.h>
+
+#include "../EffectScript.h"
+#include "VectorDataReVibed.h"
+
+class VectorEffect : public EffectScript
+{
+public:
+	EFFECT_SCRIPT(Vector);
+
+	// ========================================================================
+	// 生命周期
+	// ========================================================================
+
+	virtual void Awake() override;    // 注册 ObjectUnInitEvent（悬垂指针防护）
+	virtual void Destroy() override;  // 注销 handler
+	virtual void Clean() override;    // 组件复用：重置全部状态
+
+	virtual void OnStart() override;  // 挂载：解析 INI → 运行时参数
+
+	// 参照 MissileHoming 先例：目标单位 UnInit 时清空指针，防止悬垂
+	void OnTechnoDelete(EventSystem* sender, Event e, void* args)
+	{
+		if (args == _pLauncher)
+			_pLauncher = nullptr;
+		if (args == _pSource)
+			_pSource = nullptr;
+	}
+
+	// ========================================================================
+	// 目标缓存（挂 TechnoStatus，归一目标保护）：
+	// Techno 获得 Vector 时写入目标单位+格子（Spawn 从 SpawnManager/Kamikaze 取，普通单位记 Target）。
+	// NoUpdate=yes 存一次即停；no 每帧跟随锁定单位刷新，目标死亡冻结最后有效格子
+	// ========================================================================
+	void CacheTargetNow();
+
+	// ========================================================================
+	// 主入口：每帧计算位移
+	// ========================================================================
+	VectorResult GetVectorResult();
+
+	// ========================================================================
+	// OnStart 子步骤（.cpp 实现）
+	// ========================================================================
+	void ParseCommon();              // 计时/快照/Duration/AcquireZ
+	void ParseTargetOffset();        // _randomTargetOffset（Radius/F/L/H 两套 + Angles）
+	void ParseArcParams(bool origin); // 弧参数三件套：origin=false 主，true 大圆
+	void ParseSpeed();               // 初始速度（LinearSpeed/单位 Speed/弹体 Speed/随机）
+	void InitOrigin();               // _pLauncher/_pSource + CacheTargetNow + 按 Origin 锁定基线
+	void LockFacing();               // _facingDir/_facingRad/_tiltRad + 法向量初始化 + 角速度解析
+
+	// ========================================================================
+	// 运动状态（主/大圆共用结构；VectorEffect 持两份：_motion + _originMotion）
+	// ========================================================================
+	enum class MotionKind : int
+	{
+		None = 0,
+		MoveTo,        // 纯 FLH 位移 + GrowRate + AnglePerStep 自旋
+		ReachTarget,   // 剩余帧数均分位移，强制到达
+		Speed,         // 直线追踪 + 加速度 + 影子坐标弧高
+		Circle,        // 圆周运动（三选二参数）
+	};
+
+	struct MotionState
+	{
+		// --- 运动进度 ---
+		int elapsed = 0;                // 已执行运动帧数（主=_movementFrames 同源，大圆独立）
+		double speed = 0.0;             // 当前线速度（含加速度累加）
+		double angle = 0.0;             // 当前角度：MoveTo 自旋 / Circle 相位
+		double circleRadius = 0.0;      // Circle 动态半径
+		double circleSpeed = 0.0;       // Circle 线速度（含加速度累加）
+		double circleAngle = 0.0;       // Circle 角速度（含加速度累加）
+
+		// --- 倾斜圆面法线（NormalVector 系统）---
+		double normalRotF = 0.0;        // 法线绕 F 轴累计旋转（Lissajous 累加用）
+		double normalStepF = 0.0;       // 法线每步角速度（已解析：常数/区间随机）
+		double normalStepL = 0.0;
+		double normalStepH = 0.0;
+		double normalX = 0.0, normalY = 0.0, normalZ = 1.0; // 3D 法向量（世界坐标，增量旋转维护）
+		double lissajousStep = 0.0;     // 圆周 F 偏移角速度（°/step），0=不偏移
+
+		// --- 弧线（ReachTarget/Speed）---
+		double arcHeight = 0.0;         // 弧高（OnStart 解析随机后写入）
+		double arcPeakPercent = 0.5;    // 弧高点比率 0..1
+		double arcRotation = 0.0;       // 弧面旋转角（°），0=朝上
+
+		// --- Speed 影子坐标（弧高进度基准，不受弧高 Z 偏移污染）---
+		double shadowX = 0.0;
+		double shadowY = 0.0;
+		double shadowZ = 0.0;
+		double shadowTraveled = 0.0;    // 影子累计行走距离（含加速度/变速）
+		double prevArcOffset = 0.0;     // 上一帧弧高绝对值（增量叠加用）
+
+		// --- 大圆 Speed 弧高专用（主模式不用）---
+		double arcTotalDist = -1.0;     // 首帧初始总距离（<0=未初始化）
+		CoordStruct arcStartCenter{};   // 弧线起始圆心位置
+
+		template <typename T>
+		bool Process(T& stream)
+		{
+			return stream
+				.Process(this->elapsed)
+				.Process(this->speed)
+				.Process(this->angle)
+				.Process(this->circleRadius)
+				.Process(this->circleSpeed)
+				.Process(this->circleAngle)
+				.Process(this->normalRotF)
+				.Process(this->normalStepF)
+				.Process(this->normalStepL)
+				.Process(this->normalStepH)
+				.Process(this->normalX)
+				.Process(this->normalY)
+				.Process(this->normalZ)
+				.Process(this->lissajousStep)
+				.Process(this->arcHeight)
+				.Process(this->arcPeakPercent)
+				.Process(this->arcRotation)
+				.Process(this->shadowX)
+				.Process(this->shadowY)
+				.Process(this->shadowZ)
+				.Process(this->shadowTraveled)
+				.Process(this->prevArcOffset)
+				.Process(this->arcTotalDist)
+				.Process(this->arcStartCenter)
+				.Success();
+		}
+	};
+
+	// ========================================================================
+	// 公共数学函数（行为等价：逐字照搬旧版公式）
+	// ========================================================================
+
+	// 弧高二次曲线（ReachTarget / Speed 共用），t∈[0,1] 返回弧高绝对值
+	static double CalcArcOffsetAt(int height, double peakPercent, double t)
+	{
+		if (height == 0) return 0.0;
+		if (t <= peakPercent)
+		{
+			double u = t / peakPercent;
+			return height * u * (2.0 - u);
+		}
+		else
+		{
+			double u = (peakPercent < 1.0) ? (t - peakPercent) / (1.0 - peakPercent) : 0.0;
+			return height * (1.0 - u * u);
+		}
+	}
+	double CalcArcOffsetAt(double t) const
+	{
+		return CalcArcOffsetAt(static_cast<int>(_motion.arcHeight), _motion.arcPeakPercent, t);
+	}
+
+	// 弧面旋转：把 arcDelta 按 Rodrigues 正交基分解到 XYZ（ReachTarget/Speed 4 处共用）
+	// D = 总位移向量（frameTarget - 起点），rotDeg = 弧面旋转角，arcDelta = 本帧弧高增量
+	// 返回 double 分量：取整时机由调用点决定（绝对位置用法先加后取整，增量用法先取整后加）
+	struct ArcDelta3D { double x, y, z; };
+	static ArcDelta3D RotateArcDelta(const CoordStruct& D, double rotDeg, double arcDelta);
+
+	// 3D 法向量增量旋转（绕世界 F=Y / L=X / H=Z 轴，正速度=顺时针；主/大圆共用）
+	static void RotateNormal3D(double& nx, double& ny, double& nz,
+		double stepF, double stepL, double stepH);
+
+	// 法线角速度解析：常数优先，否则区间2 50% 随机，否则区间1 随机（主/大圆共用）
+	static double ResolveAngleStep(double perStep, double m1, double M1, double m2, double M2);
+
+	// 三态跟踪：NoUpdate=yes → 冻结 last；no + 单位存活 → 每帧快照 last；死亡 → 冻结 last
+	// 主 Origin（_initialOriginPos）与大圆基座（_initialBaseCenter）共用
+	static CoordStruct TrackOriginCoord(ObjectClass* pUnit, bool noUpdate, CoordStruct& last);
+
+	// Target 多级读取链（缓存 → 弹体 → 单位 → Kamikaze/SpawnManager），返回是否取到
+	bool GetTargetPosFromChain(CoordStruct& out, bool preferCache = true);
+
+	// ========================================================================
+	// 状态变量（分组）
+	// ========================================================================
+
+	// --- 计时/帧 ---
+	int _elapsedFrames = 0;             // 已执行运动帧数（含 TimeStep 跳帧）
+	int _moveFrame = 0;                 // 真实帧计数
+	int _movementFrames = 0;            // 有效运动帧数（不含 InitialDelay/TimeStep 跳帧）
+	int _effectiveTimeStep = 1;         // 有效 TimeStep
+	int _totalDuration = 0;             // AE 总持续时间（ReachTarget 用，已除 TimeStep）
+
+	// --- 快照/引用 ---
+	CoordStruct _initialLocation{};     // 首帧位置快照（弧线基准/Freeze 锚点）
+	CoordStruct _initialOriginPos{};    // 主 Origin 最后有效坐标（OnStart 锁定 + 每帧跟随）
+	CoordStruct _initialBaseCenter{};   // 大圆基座最后有效坐标（OriginOriginNoUpdate 冻结用）
+	int _vectorAcquireZ = 0;            // 获取 Vector 时的抛射体 Z（Circle 圆心高度基准）
+	ObjectClass* _pLauncher = nullptr;  // 发射者（OnTechnoDelete 置空防悬垂）
+	ObjectClass* _pSource = nullptr;    // AE 来源（同上）
+
+	// --- 朝向（主模式参考系）---
+	double _facingRad = 0.0;            // OnStart 锁定的朝向弧度（FLH 旋转用）
+	DirStruct _facingDir;               // OnStart 锁定的朝向（Point2Dir 结果，Target/Source）
+	double _tiltRad = 0.0;              // F 轴俯仰角（AllowedTilt 用）
+
+	// --- 大圆朝向（独立参考系）---
+	double _originFacing = 0.0;         // 大圆有效 facing
+	double _originTilt = 0.0;           // 大圆有效 tilt
+
+	// --- 目标偏移 ---
+	CoordStruct _randomTargetOffset{};  // 主 TargetFLH 随机偏移（首帧解析）
+	CoordStruct _originTargetOffset{};  // 大圆 TargetFLH 随机偏移
+
+	// --- 大圆圆心运动 ---
+	CoordStruct _originOffset{};        // 圆心相对基座偏移（首帧 0，每帧累加 disp）
+	CoordStruct _prevCircleCenter{};    // 上一帧圆心位置（计算叠加位移用）
+	CoordStruct _circlePos{};           // 圆上内部跟踪位置（增量位移，不打架 MoveTo）
+
+	// --- 运动状态（主 + 大圆）---
+	MotionState _motion{};              // 主运动状态
+	MotionState _originMotion{};        // 大圆圆心运动状态
+
+	// ========================================================================
+	// 帧工具
+	// ========================================================================
+	bool ShouldMoveThisFrame() const
+	{
+		return (_moveFrame % _effectiveTimeStep) == 0;
+	}
+	void AdvanceFrame()
+	{
+		_elapsedFrames++;
+		_moveFrame++;
+	}
+
+#pragma region Save/Load
+	template <typename T>
+	bool Serialize(T& stream)
+	{
+		stream
+			.Process(this->_elapsedFrames)
+			.Process(this->_moveFrame)
+			.Process(this->_movementFrames)
+			.Process(this->_effectiveTimeStep)
+			.Process(this->_totalDuration)
+			.Process(this->_initialLocation)
+			.Process(this->_initialOriginPos)
+			.Process(this->_initialBaseCenter)
+			.Process(this->_vectorAcquireZ)
+			.Process(this->_pLauncher)
+			.Process(this->_pSource)
+			.Process(this->_facingRad)
+			.Process(this->_facingDir)
+			.Process(this->_tiltRad)
+			.Process(this->_originFacing)
+			.Process(this->_originTilt)
+			.Process(this->_randomTargetOffset)
+			.Process(this->_originTargetOffset)
+			.Process(this->_originOffset)
+			.Process(this->_prevCircleCenter)
+			.Process(this->_circlePos)
+			.Process(this->_motion)
+			.Process(this->_originMotion);
+		return stream.Success();
+	};
+
+	virtual bool Load(ExStreamReader& stream, bool registerForChange) override
+	{
+		EffectScript::Load(stream, registerForChange);
+		return this->Serialize(stream);
+	}
+	virtual bool Save(ExStreamWriter& stream) const override
+	{
+		EffectScript::Save(stream);
+		return const_cast<VectorEffect*>(this)->Serialize(stream);
+	}
+#pragma endregion
+};

--- a/src/Ext/ObjectType/AttachEffect.cpp
+++ b/src/Ext/ObjectType/AttachEffect.cpp
@@ -18,7 +18,7 @@
 #include <Ext/EffectType/Effect/AttackBeaconEffect.h>
 #include <Ext/EffectType/Effect/CounterEffect.h>
 #include <Ext/EffectType/Effect/StandEffect.h>
-#include <Ext/EffectType/Effect/VectorEffect.h>
+#include <Ext/EffectType/Effect/VectorEffectReVibed.h>
 #include <Ext/EffectType/Effect/TurretSpinEffect.h>
 #include <Ext/EffectType/Effect/BodySpinEffect.h>
 #include <Ext/BulletType/BulletStatus.h>

--- a/src/Ext/TechnoType/Status/Vector.cpp
+++ b/src/Ext/TechnoType/Status/Vector.cpp
@@ -9,9 +9,13 @@
 
 void TechnoStatus::VectorCancel()
 {
+	// 保存当前攻击目标及移动目标，Vector结束后恢复
+	AbstractClass* savedTarget = pTechno->Target;
+	AbstractClass* savedFocus = pTechno->Focus;
+	FootClass* pFoot = abstract_cast<FootClass*>(pTechno);
+
 	if (!IsBuilding() && !IsDeadOrInvisible(pTechno))
 	{
-		FootClass* pFoot = abstract_cast<FootClass*, true>(pTechno);
 		pFoot->Locomotor->Unlock();
 		// 恢复原 Locomotor
 		if (dynamic_cast<JumpjetLocomotionClass*>(pFoot->Locomotor.get()))
@@ -38,6 +42,18 @@ void TechnoStatus::VectorCancel()
 	VectorFreezeActive = false;
 	_vectorDesiredPos = CoordStruct::Empty;
 	_vectorResult = {};
+	_savedVectorTarget = nullptr;
+
+	// 恢复被清空的攻击目标和移动目标
+	if (savedTarget && !IsDeadOrInvisible(abstract_cast<ObjectClass*>(savedTarget)))
+	{
+		pTechno->SetTarget(savedTarget);
+		pTechno->QueueMission(Mission::Attack, false);
+	}
+	else if (savedFocus && !IsDeadOrInvisible(abstract_cast<ObjectClass*>(savedFocus)))
+	{
+		pTechno->SetFocus(savedFocus);
+	}
 }
 
 
@@ -68,6 +84,19 @@ void TechnoStatus::OnUpdate_Vector()
 	{
 		VectorForced = true;
 		VectorPendingFall = false;
+
+		// 首次进入 Vector：锁定当前目标
+		if (!wasVectorForced)
+		{
+			_savedVectorTarget = pTechno->Target;
+		}
+		// 每帧恢复：引擎可能清Target，强制重设
+		if (_savedVectorTarget && !IsDeadOrInvisible(abstract_cast<ObjectClass*>(_savedVectorTarget)))
+		{
+			pTechno->SetTarget(_savedVectorTarget);
+			pTechno->QueueMission(Mission::Attack, false);
+		}
+
 		if (_vectorResult.Freeze)
 			VectorFreezeActive = true;
 

--- a/src/Ext/TechnoType/Status/Vector.cpp
+++ b/src/Ext/TechnoType/Status/Vector.cpp
@@ -13,8 +13,6 @@ void TechnoStatus::VectorCancel()
 	AbstractClass* savedTarget = pTechno->Target;
 	AbstractClass* savedFocus = pTechno->Focus;
 	FootClass* pFoot = abstract_cast<FootClass*>(pTechno);
-	Debug::Log("[VectorReach] END VectorCancel pos=(%d,%d,%d)\n",
-		pTechno->GetCoords().X, pTechno->GetCoords().Y, pTechno->GetCoords().Z);
 
 	if (!IsBuilding() && !IsDeadOrInvisible(pTechno))
 	{
@@ -45,6 +43,9 @@ void TechnoStatus::VectorCancel()
 	_vectorDesiredPos = CoordStruct::Empty;
 	_vectorResult = {};
 	_savedVectorTarget = nullptr;
+	_vectorCachedTarget = nullptr;
+	_vectorCachedCell = {};
+	_vectorCachedCellValid = false;
 
 	// 恢复被清空的攻击目标和移动目标
 	if (savedTarget && !IsDeadOrInvisible(abstract_cast<ObjectClass*>(savedTarget)))

--- a/src/Ext/TechnoType/Status/Vector.cpp
+++ b/src/Ext/TechnoType/Status/Vector.cpp
@@ -13,6 +13,8 @@ void TechnoStatus::VectorCancel()
 	AbstractClass* savedTarget = pTechno->Target;
 	AbstractClass* savedFocus = pTechno->Focus;
 	FootClass* pFoot = abstract_cast<FootClass*>(pTechno);
+	Debug::Log("[VectorReach] END VectorCancel pos=(%d,%d,%d)\n",
+		pTechno->GetCoords().X, pTechno->GetCoords().Y, pTechno->GetCoords().Z);
 
 	if (!IsBuilding() && !IsDeadOrInvisible(pTechno))
 	{
@@ -220,7 +222,9 @@ void TechnoStatus::OnUpdate_Vector()
 
 void TechnoStatus::OnUpdateEnd_Vector()
 {
-	if (VectorForced && !IsBuilding() && !IsDeadOrInvisible(pTechno) && !_vectorDesiredPos.IsEmpty())
+	// VectorForced 或过渡帧（VectorPendingFall，AE 已移除但未交还）都锁位到目标点，
+	// 防止 Aircraft 等引擎在 Vector 结束瞬间接管飞离目标
+	if ((VectorForced || VectorPendingFall) && !IsBuilding() && !IsDeadOrInvisible(pTechno) && !_vectorDesiredPos.IsEmpty())
 	{
 		CoordStruct currentPos = pTechno->GetCoords();
 		if (currentPos != _vectorDesiredPos)

--- a/src/Ext/TechnoType/Status/Vector.cpp
+++ b/src/Ext/TechnoType/Status/Vector.cpp
@@ -26,12 +26,12 @@ void TechnoStatus::VectorCancel()
 		{
 			pFoot->ForceMission(Mission::Guard);
 		}
-		// 坠落：取当前高度对地差值或 AllowFallingDestroy 指定高度
-		CellClass* pCell = MapClass::Instance->TryGetCellAt(pTechno->GetCoords());
-		int heightAboveGround = pCell ? (pTechno->GetCoords().Z - pCell->GetCoordsWithBridge().Z) : 0;
-		int fallingDestroyHeight = _vectorResult.AllowFallingDestroy
-			? _vectorResult.FallingDestroyHeight
-			: 0; // AllowFallingDestroy=no 时不判死，自然坠落
+		// 摔死
+		int fallingDestroyHeight = 0;
+		if (_vectorResult.AllowFallingDestroy)
+		{
+			fallingDestroyHeight = _vectorResult.FallingDestroyHeight;
+		}
 		FallingExceptAircraft(pTechno, fallingDestroyHeight, false);
 	}
 	VectorForced = false;

--- a/src/Ext/TechnoType/TechnoStatus.h
+++ b/src/Ext/TechnoType/TechnoStatus.h
@@ -198,6 +198,11 @@ public:
 		// 阿伟死了，DestroySelfState干的
 		_isDead = false;
 
+		// Vector 目标缓存
+		_vectorCachedTarget = nullptr;
+		_vectorCachedCell = {};
+		_vectorCachedCellValid = false;
+
 		_lastMission = Mission::Guard;
 
 		_location = CoordStruct::Empty;
@@ -421,6 +426,23 @@ public:
 	CoordStruct _vectorDesiredPos{};
 	GUID _vectorSavedLocomotor{}; // Vector 接管时保存的原 Locomotor
 	AbstractClass* _savedVectorTarget = nullptr; // Vector 接管时锁定的攻击目标
+
+	// Vector 目标缓存（归一目标保护机制到 Spawn）：
+	// 目标单位（存活时有效）+ 目标格子（死亡后仍有效，唯一可靠值）。
+	// Techno 获得第一个 Vector 时写入，NoUpdate=no 每帧刷新，目标死亡后冻结格子不再更新
+	AbstractClass* _vectorCachedTarget = nullptr;
+	CoordStruct _vectorCachedCell{};
+	bool _vectorCachedCellValid = false;
+
+	bool HasVectorTargetCache() const { return _vectorCachedCellValid; }
+	CoordStruct GetVectorCachedCell() const { return _vectorCachedCell; }
+	void SetVectorTargetCache(AbstractClass* pTarget, const CoordStruct& cell)
+	{
+		_vectorCachedTarget = pTarget;
+		_vectorCachedCell = cell;
+		_vectorCachedCellValid = true;
+	}
+
 	double _spinRad = 0;
 	int _spinTime = 0;
 	bool _spinFlip = true;
@@ -520,6 +542,9 @@ public:
 			.Process(this->_turretFlip)
 			.Process(this->_vectorResult)
 			.Process(this->_savedVectorTarget)
+			.Process(this->_vectorCachedTarget)
+			.Process(this->_vectorCachedCell)
+			.Process(this->_vectorCachedCellValid)
 			.Success();
 	};
 	virtual bool Load(ExStreamReader& stream, bool registerForChange) override

--- a/src/Ext/TechnoType/TechnoStatus.h
+++ b/src/Ext/TechnoType/TechnoStatus.h
@@ -519,6 +519,7 @@ public:
 			.Process(this->_turretTime)
 			.Process(this->_turretFlip)
 			.Process(this->_vectorResult)
+			.Process(this->_savedVectorTarget)
 			.Success();
 	};
 	virtual bool Load(ExStreamReader& stream, bool registerForChange) override

--- a/src/Ext/TechnoType/TechnoStatus.h
+++ b/src/Ext/TechnoType/TechnoStatus.h
@@ -420,6 +420,7 @@ public:
 	bool VectorFreezeActive = false;
 	CoordStruct _vectorDesiredPos{};
 	GUID _vectorSavedLocomotor{}; // Vector 接管时保存的原 Locomotor
+	AbstractClass* _savedVectorTarget = nullptr; // Vector 接管时锁定的攻击目标
 	double _spinRad = 0;
 	int _spinTime = 0;
 	bool _spinFlip = true;

--- a/src/Ext/TechnoType/TechnoStatus.h
+++ b/src/Ext/TechnoType/TechnoStatus.h
@@ -436,6 +436,7 @@ public:
 
 	bool HasVectorTargetCache() const { return _vectorCachedCellValid; }
 	CoordStruct GetVectorCachedCell() const { return _vectorCachedCell; }
+	AbstractClass* GetVectorCachedTarget() const { return _vectorCachedTarget; }
 	void SetVectorTargetCache(AbstractClass* pTarget, const CoordStruct& cell)
 	{
 		_vectorCachedTarget = pTarget;

--- a/src/Hooks/BulletExtHook.cpp
+++ b/src/Hooks/BulletExtHook.cpp
@@ -371,4 +371,41 @@ DEFINE_HOOK(0x467E53, BulletClass_AI_PreDetonation_Vector, 0x6)
 	// Vector 不存在或已结束，进入原版引爆流程
 	return 0;
 }
+
+// Vector 期间 ROT 导弹引信判定取消（修复 SyncFacing=yes 提前爆炸）
+// FuseClass::Checkup 的调用在 0x467C35，本 hook 设在调用返回后的 0x467C3A。
+// fuseResult：0=继续飞行，1=真正到达目标附近，2=距离开始增大（判定已经越过目标）
+// SyncFacing=yes 时 Vector 用 GetBulletVelocity 改 Velocity 方向，ROT 导弹引擎轨迹
+// 每帧按新方向转向，引信误判"到达/越过目标"（1/2）→ 提前爆炸。
+// VectorForced 期间持有 Vector 的弹体不该爆：1、2 都改 0（继续飞），
+// 引爆由 Vector 结束后恢复（VectorForced 变假 → 引信正常判定 → 引爆）。
+// 非 ROT 弹体/其他引爆路径由 0x467E53 兜底。
+// 原始字节：8B F0 8B 8D B0 00 00 00（mov esi,eax; mov ecx,[ebp+0B0h]）
+DEFINE_HOOK(0x467C3A, BulletClass_AI_ROTFuse_Vector, 0x8)
+{
+	GET(BulletClass*, pThis, EBP);
+	GET(int, fuseResult, EAX);
+
+	// Vector 接管期间，取消 ROT 导弹的一切引信判爆（到达/越过都继续飞）
+	if (fuseResult != 0
+		&& pThis->Type
+		&& pThis->Type->ROT > 0)
+	{
+		if (BulletStatus* status = GetStatus<BulletExt, BulletStatus>(pThis))
+		{
+			if (status->VectorForced)
+			{
+				fuseResult = 0;
+			}
+		}
+	}
+
+	// 回填被 Hook 覆盖的两条指令
+	// 注意：[ebp+0xB0] 是 Owner（不是 Target），必须恢复 R->ECX(pThis->Owner)
+	R->EAX(fuseResult);
+	R->ESI(fuseResult);
+	R->ECX(pThis->Owner);
+
+	return 0;
+}
 #pragma endregion

--- a/src/Hooks/BulletExtHook.cpp
+++ b/src/Hooks/BulletExtHook.cpp
@@ -345,3 +345,30 @@ DEFINE_HOOK(0x466E18, BulletClass_CheckHight_UnderGround, 0x6)
 	return 0;
 }
 #pragma endregion
+
+#pragma region Vector KeepAlive
+
+// Vector 存在期间暴力跳过"抛射体抵达目标进入引爆流程"
+// 原流程：0x467E53 进入预爆动画 / Detonate / UnInit，弹体消失
+// 新流程：弹体仍被 Vector 接管（复用 BulletStatus::OnUpdate_Vector 每帧
+//         MarginVectorOffset 的现成结果，不重复遍历判定）→ 跳到 0x467FBA
+//         （跳过引爆三段），弹体保持存活并继续被 Vector 位移控制；
+//         Vector 结束 → 判据变假，走原版引爆流程。
+// 原始字节：8B 8D 28 01 00 00（mov ecx, [ebp+0x128]）
+DEFINE_HOOK(0x467E53, BulletClass_AI_PreDetonation_Vector, 0x6)
+{
+	GET(BulletClass*, pThis, EBP);
+
+	if (BulletStatus* status = GetStatus<BulletExt, BulletStatus>(pThis))
+	{
+		if (status->HasActiveVector())
+		{
+			// 跳过预爆动画、Detonate 和 UnInit，继续帧尾记录以及 0x467FEE 的 OnUpdateEnd
+			return 0x467FBA;
+		}
+	}
+
+	// Vector 不存在或已结束，进入原版引爆流程
+	return 0;
+}
+#pragma endregion


### PR DESCRIPTION
伪装AE，获得时自动从池子里面选择伪装对象。支持步兵坦克建筑，Aircraft没试过
存在一坨bug：
有炮塔vxl伪装成有炮塔shp车时无炮塔
我方建筑伪装时我方视角只能隐藏本体动画，无法显示伪装对象动画
敌方建筑伪装时无法实时刷新外形，只有在发生建筑外形变更如单位进驻民房时候才刷新，此外也看不见工作动画