### PR TITLE
修复 TurretSpin 效果器无法旋转炮塔

### DIFF
--- a/src/Ext/TechnoType/Status/TurretSpin.cpp
+++ b/src/Ext/TechnoType/Status/TurretSpin.cpp
@@ -6,11 +6,17 @@
 void TechnoStatus::OnUpdate_TurretSpin()
 {
 	if (!pTechno || IsDeadOrInvisible(pTechno))
+	{
+		_turretSpinActive = false;
 		return;
+	}
 
 	AttachEffect* aem = AEManager();
 	if (!aem)
+	{
+		_turretSpinActive = false;
 		return;
+	}
 
 	TurretSpinData* pData = nullptr;
 	aem->ForeachChild([&pData](Component* c) {
@@ -21,7 +27,12 @@ void TechnoStatus::OnUpdate_TurretSpin()
 		}
 	});
 	if (!pData)
+	{
+		_turretSpinActive = false;
 		return;
+	}
+	// 激活标志供 Rotation_AI 的 hook 读取：跳过引擎对炮塔朝向的瞄准/回正覆写
+	_turretSpinActive = true;
 
 	int speed = pData->Speed;
 	int period = pData->SweepPeriod;

--- a/src/Ext/TechnoType/TechnoStatus.cpp
+++ b/src/Ext/TechnoType/TechnoStatus.cpp
@@ -204,8 +204,10 @@ void TechnoStatus::OnUpdate()
 		OnUpdate_Paintball();
 		OnUpdate_Passenger();
 		OnUpdate_TargetLaser();
+		// TurretSpin AE 激活时，引擎 Rotation_AI 的瞄准/回正写入已被 UnitExtHook 的
+		// 0x736A26/0x736BBB/0x736BCA 拦截跳过，此处只做每帧累加写入炮塔朝向
+		OnUpdate_TurretSpin();
 		OnUpdate_GiftBox(); // 礼盒会删除对象，所以放最后
-		OnUpdate_TurretSpin(); // 炮塔旋转最后执行，避免引擎瞄准覆盖
 	}
 }
 

--- a/src/Ext/TechnoType/TechnoStatus.h
+++ b/src/Ext/TechnoType/TechnoStatus.h
@@ -455,6 +455,9 @@ public:
 	double _turretRad = 0;
 	int _turretTime = 0;
 	bool _turretFlip = true;
+	// TurretSpin AE 激活中：Rotation_AI 每帧读到该标志即跳过引擎对炮塔朝向的自动覆写，
+	// 使炮塔朝向完全由 OnUpdate_TurretSpin 每帧写入（运行期瞬时标志，不参与序列化）
+	bool _turretSpinActive = false;
 	bool Jumping = false;
 
 	// 冻结

--- a/src/Hooks/UnitExtHook.cpp
+++ b/src/Hooks/UnitExtHook.cpp
@@ -261,6 +261,13 @@ DEFINE_HOOK(0x736A26, UnitClass_Rotation_SetTurretFacingToTarget_Skip, 0x6)
 {
 	GET(TechnoClass*, pTechno, ESI);
 
+	// TurretSpin AE 激活时炮塔始终自旋，跳过引擎朝目标的瞄准写入（有目标也覆盖瞄准）
+	TechnoStatus* tStatus = nullptr;
+	if (TryGetStatus<TechnoExt, TechnoStatus>(pTechno, tStatus) && tStatus->_turretSpinActive)
+	{
+		return 0x736A8E;
+	}
+
 	TurretAngle* status = nullptr;
 	if (TryGetScript<TechnoExt, TurretAngle>(pTechno, status) && status->LockTurret)
 	{
@@ -273,6 +280,13 @@ DEFINE_HOOK(0x736A26, UnitClass_Rotation_SetTurretFacingToTarget_Skip, 0x6)
 DEFINE_HOOK(0x736BCA, UnitClass_Rotation_SetTurretFacing_NoTargetAndStanding, 0x5)
 {
 	GET(TechnoClass*, pTechno, ESI);
+
+	// TurretSpin AE 激活时炮塔始终自旋，跳过引擎无目标时的回正写入
+	TechnoStatus* tStatus = nullptr;
+	if (TryGetStatus<TechnoExt, TechnoStatus>(pTechno, tStatus) && tStatus->_turretSpinActive)
+	{
+		return 0x736BE2;
+	}
 
 	TurretAngle* status = nullptr;
 	if (TryGetScript<TechnoExt, TurretAngle>(pTechno, status) && status->ChangeDefaultDir)
@@ -287,6 +301,13 @@ DEFINE_HOOK(0x736BCA, UnitClass_Rotation_SetTurretFacing_NoTargetAndStanding, 0x
 DEFINE_HOOK(0x736BBB, UnitClass_Rotation_SetTurretFacing_NoTargetAndMoving, 0x5)
 {
 	GET(TechnoClass*, pTechno, ESI);
+
+	// TurretSpin AE 激活时炮塔始终自旋，跳过引擎无目标时的回正写入
+	TechnoStatus* tStatus = nullptr;
+	if (TryGetStatus<TechnoExt, TechnoStatus>(pTechno, tStatus) && tStatus->_turretSpinActive)
+	{
+		return 0x736BE2;
+	}
 
 	TurretAngle* status = nullptr;
 	if (TryGetScript<TechnoExt, TurretAngle>(pTechno, status) && status->LockTurret)


### PR DESCRIPTION
跳过引擎对炮塔朝向的瞄准/回正覆写。使用Turret.Angel 同款沟子