### PR TITLE
新增 Copy 与 Trace 效果器族：观察现有 AE 来源并按名单附加/清理

### DIFF
--- a/Kratos.vcxproj
+++ b/Kratos.vcxproj
@@ -81,6 +81,8 @@
     <ClCompile Include="src\Ext\EffectType\Effect\StackEffect.cpp" />
     <ClCompile Include="src\Ext\EffectType\Effect\StandEffect.cpp" />
     <ClCompile Include="src\Ext\EffectType\Effect\VampireEffect.cpp" />
+    <ClCompile Include="src\Ext\EffectType\Effect\CopyEffect.cpp" />
+    <ClCompile Include="src\Ext\EffectType\Effect\TraceEffect.cpp" />
     <ClCompile Include="src\Ext\EffectType\Effect\VectorEffect.cpp" />
     <ClCompile Include="src\Ext\EffectType\Effect\TurretSpinEffect.cpp" />
     <ClCompile Include="src\Ext\EffectType\Effect\BodySpinEffect.cpp" />

--- a/src/Ext/EffectType/AttachEffectData.h
+++ b/src/Ext/EffectType/AttachEffectData.h
@@ -31,6 +31,8 @@
 #include "Effect/TurretSpinData.h"
 #include "Effect/BodySpinData.h"
 #include "Effect/VampireData.h"
+#include "Effect/CopyData.h"
+#include "Effect/TraceData.h"
 // State Effects
 #include <Ext/StateType/State/AntiBulletData.h>
 #include <Ext/StateType/State/BlackHoleData.h>
@@ -179,6 +181,8 @@ public:
 	EFFECT_VAR_DEFINE(TurretSpin);
 	EFFECT_VAR_DEFINE(BodySpin);
 	EFFECT_VAR_DEFINE(Vampire);
+	EFFECT_VAR_DEFINE(Copy);
+	EFFECT_VAR_DEFINE(Trace);
 	// State Effects
 	EFFECT_VAR_DEFINE(AntiBullet);
 	EFFECT_VAR_DEFINE(BlackHole);
@@ -224,6 +228,8 @@ public:
 		EFFECT_VAR_READ(TurretSpin);
 		EFFECT_VAR_READ(BodySpin);
 		EFFECT_VAR_READ(Vampire);
+		EFFECT_VAR_READ(Copy);
+		EFFECT_VAR_READ(Trace);
 		// State Effects
 		EFFECT_VAR_READ(AntiBullet);
 		EFFECT_VAR_READ(BlackHole);
@@ -252,6 +258,8 @@ public:
 		EFFECT_VAR_SCRIPT_NAME(Vector);
 		EFFECT_VAR_SCRIPT_NAME(TurretSpin);
 		EFFECT_VAR_SCRIPT_NAME(BodySpin);
+		EFFECT_VAR_SCRIPT_NAME(Copy);
+		EFFECT_VAR_SCRIPT_NAME(Trace);
 
 		EFFECT_VAR_SCRIPT_NAME(Animation);
 		EFFECT_VAR_SCRIPT_NAME(AttackBeacon);
@@ -322,6 +330,8 @@ public:
 			EFFECT_VAR_PROCESS(TurretSpin)
 			EFFECT_VAR_PROCESS(BodySpin)
 			EFFECT_VAR_PROCESS(Vampire)
+			EFFECT_VAR_PROCESS(Copy)
+			EFFECT_VAR_PROCESS(Trace)
 			// State Effects
 			EFFECT_VAR_PROCESS(AntiBullet)
 			EFFECT_VAR_PROCESS(BlackHole)

--- a/src/Ext/EffectType/Effect/CopyData.h
+++ b/src/Ext/EffectType/Effect/CopyData.h
@@ -1,0 +1,256 @@
+﻿#pragma once
+// ============================================================================
+// CopyData — Copy 与 Trace 的公共数据基础（同源族）
+//
+// 两个效果器共用同一套机制：观察指定单位身上正在生效的 AE（Watch/Ignore 名单），
+// 把观察结果换成"要附加的内容"（Copy = 命中 AE 本身；Trace = INI 固定名单），
+// 按 AttachTo（贴给谁）/ AttachFrom（来源记谁）分发到选定目标，附加一律走现有 Attach 基建。
+//
+// 本文件定义三组取值枚举、观察组结构与 Copy 的数据类：
+//   CopyAttachTo    贴给谁（Copy 支持 Return；Trace 经 CopyParseAttachTo 限三值）
+//   CopyAttachFrom  来源记谁（带死亡回退链）
+//   CopyFrom        观察谁身上的 AE
+//   CopyWatchConfig 观察名单组（Watch/WatchMarks 白名单 + IgnoreTypes/IgnoreMarks 黑名单；
+//                   白名单空 = 全量观察，无额外开关）
+// 机制解耦（每个标签只管自己定义的那件事）：
+//   Watch/Ignore   只管"观察哪些 AE 当线索"
+//   AttachTo       只管"贴给谁"（目标死活 -> 是否贴）
+//   AttachFrom     只管"来源记谁"（死亡回退链恒常，与贴判定无关）
+//   Discard        只管"死源丢弃 / 走回退"
+//   Cut（仅 Copy） 只管"贴前移除观察源身上命中名单的源 AE"
+//   Affect*/Marks  只管"发放对象检查"（基类 FilterData 字段）
+// ============================================================================
+
+#include <string>
+#include <vector>
+
+#include <GeneralStructures.h>
+
+#include <Common/INI/INIConfig.h>
+
+#include <Ext/EffectType/Effect/EffectData.h>
+#include <Ext/Helper/StringEx.h> // ClearIfGetNone
+
+// 粘贴对象选择（AttachTo 的取值）
+enum class CopyAttachTo : int
+{
+	Source = 0,        // 整份内容 -> 挂效果器 AE 的单位（默认）
+	Target = 1,        // 整份内容 -> 宿主自己
+	InitialSource = 2, // 广播：先出观察命中 AE 的来源去重清单，每个来源都收到整份内容
+	Return = 3,        // 逐条返还：每条命中 AE 只发回它自己的初始来源（Copy 专属）
+};
+
+// 按首字母解析 AttachTo 取值；allowReturn=false 时不接受 Return（Trace 用）
+inline bool CopyParseAttachTo(const char* pValue, bool allowReturn, CopyAttachTo* outValue)
+{
+	switch (toupper(static_cast<unsigned char>(*pValue)))
+	{
+	case 'S':
+		if (outValue)
+		{
+			*outValue = CopyAttachTo::Source;
+		}
+		return true;
+	case 'T':
+		if (outValue)
+		{
+			*outValue = CopyAttachTo::Target;
+		}
+		return true;
+	case 'I':
+		if (outValue)
+		{
+			*outValue = CopyAttachTo::InitialSource;
+		}
+		return true;
+	case 'R':
+		if (allowReturn)
+		{
+			if (outValue)
+			{
+				*outValue = CopyAttachTo::Return;
+			}
+			return true;
+		}
+		break;
+	default:
+		break;
+	}
+	if (outValue)
+	{
+		*outValue = CopyAttachTo::Source;
+	}
+	return true;
+}
+
+template <>
+inline bool Parser<CopyAttachTo>::TryParse(const char* pValue, CopyAttachTo* outValue)
+{
+	return CopyParseAttachTo(pValue, true, outValue);
+}
+
+// 附加来源设置（AttachFrom 的取值）
+enum class CopyAttachFrom : int
+{
+	InitialSource = 0, // 各条保持观察命中 AE 自己的来源（默认）
+	Source = 1,        // 全部来源强制记挂效果器 AE 的单位
+	Target = 2,        // 全部来源强制记宿主
+};
+
+template <>
+inline bool Parser<CopyAttachFrom>::TryParse(const char* pValue, CopyAttachFrom* outValue)
+{
+	switch (toupper(static_cast<unsigned char>(*pValue)))
+	{
+	case 'S':
+		if (outValue)
+		{
+			*outValue = CopyAttachFrom::Source;
+		}
+		return true;
+	case 'T':
+		if (outValue)
+		{
+			*outValue = CopyAttachFrom::Target;
+		}
+		return true;
+	case 'I':
+		if (outValue)
+		{
+			*outValue = CopyAttachFrom::InitialSource;
+		}
+		return true;
+	default:
+		if (outValue)
+		{
+			*outValue = CopyAttachFrom::InitialSource;
+		}
+		return true;
+	}
+}
+
+// 观察谁身上的 AE（From 的取值）
+enum class CopyFrom : int
+{
+	Target = 0, // 效果器 AE 的附着对象（宿主，默认）
+	Source = 1, // 挂效果器 AE 的单位
+};
+
+template <>
+inline bool Parser<CopyFrom>::TryParse(const char* pValue, CopyFrom* outValue)
+{
+	switch (toupper(static_cast<unsigned char>(*pValue)))
+	{
+	case 'S':
+		if (outValue)
+		{
+			*outValue = CopyFrom::Source;
+		}
+		return true;
+	case 'T':
+		if (outValue)
+		{
+			*outValue = CopyFrom::Target;
+		}
+		return true;
+	default:
+		if (outValue)
+		{
+			*outValue = CopyFrom::Target;
+		}
+		return true;
+	}
+}
+
+// 观察名单组（主效果器与 Trace 各持一份；过滤判定逻辑共用）
+//   Watch / WatchMarks      白名单（AE 名 / AE 自带标记）；空 = 全量
+//   IgnoreTypes / IgnoreMarks 黑名单（AE 名 / AE 自带标记，优先）
+struct CopyWatchConfig
+{
+	std::vector<std::string> Watch{};
+	std::vector<std::string> WatchMarks{};
+	std::vector<std::string> IgnoreTypes{};
+	std::vector<std::string> IgnoreMarks{};
+
+	void Read(INIBufferReader* reader, std::string title)
+	{
+		Watch = reader->GetList(title + "Watch", Watch);
+		ClearIfGetNone(Watch);
+		WatchMarks = reader->GetList(title + "WatchMarks", WatchMarks);
+		ClearIfGetNone(WatchMarks);
+		IgnoreTypes = reader->GetList(title + "IgnoreTypes", IgnoreTypes);
+		ClearIfGetNone(IgnoreTypes);
+		IgnoreMarks = reader->GetList(title + "IgnoreMarks", IgnoreMarks);
+		ClearIfGetNone(IgnoreMarks);
+	}
+};
+
+class CopyData : public EffectData
+{
+public:
+	EFFECT_DATA(Copy);
+
+	// ---- 主效果器（前缀 Copy.*）----
+	CopyFrom From = CopyFrom::Target;                       // INI: Copy.From（观察谁身上的 AE）
+	CopyWatchConfig Watch{};                                // INI: Copy.Watch / WatchMarks / IgnoreTypes / IgnoreMarks（观察名单组）
+	CopyAttachTo AttachTo = CopyAttachTo::Source;           // INI: Copy.AttachTo（贴给谁，含 Return）
+	CopyAttachFrom AttachFrom = CopyAttachFrom::InitialSource; // INI: Copy.AttachFrom（来源记谁）
+	bool DiscardOnInitialSourceDead = false;                // INI: Copy.DiscardOnInitialSourceDead（死源清单级丢弃 / 走回退）
+	bool Cut = false;                                       // INI: Copy.Cut（贴前移除观察源身上命中清单的源 AE）
+	int Delay = 0;                                          // INI: Copy.Delay（执行间隔帧，<=0 按 1 帧）
+
+	CopyData() : EffectData()
+	{
+		// TriggeredTimes（基类键 Copy.TriggeredTimes）= 总执行次数，默认 1（激活执行 1 次即耗尽）
+		this->TriggeredTimes = 1;
+	}
+
+	virtual void Read(INIBufferReader* reader) override
+	{
+		Read(reader, "Copy.");
+	}
+
+	virtual void Read(INIBufferReader* reader, std::string title) override
+	{
+		// 直接复用基类读取（Copy.Enable / Copy.TriggeredTimes / Copy.AffectTypes 等发放过滤键）
+		EffectData::Read(reader, title);
+
+		From = reader->Get(title + "From", From);
+		Watch.Read(reader, title);
+		AttachTo = reader->Get(title + "AttachTo", AttachTo);
+		AttachFrom = reader->Get(title + "AttachFrom", AttachFrom);
+		DiscardOnInitialSourceDead = reader->Get(title + "DiscardOnInitialSourceDead", DiscardOnInitialSourceDead);
+		Cut = reader->Get(title + "Cut", Cut);
+		Delay = reader->Get(title + "Delay", Delay);
+	}
+
+#pragma region save/load
+	template <typename T>
+	bool Serialize(T& stream)
+	{
+		return stream
+			.Process(this->From)
+			.Process(this->Watch.Watch)
+			.Process(this->Watch.WatchMarks)
+			.Process(this->Watch.IgnoreTypes)
+			.Process(this->Watch.IgnoreMarks)
+			.Process(this->AttachTo)
+			.Process(this->AttachFrom)
+			.Process(this->DiscardOnInitialSourceDead)
+			.Process(this->Cut)
+			.Process(this->Delay)
+			.Success();
+	};
+
+	virtual bool Load(ExStreamReader& stream, bool registerForChange) override
+	{
+		EffectData::Load(stream, registerForChange);
+		return this->Serialize(stream);
+	}
+	virtual bool Save(ExStreamWriter& stream) const override
+	{
+		EffectData::Save(stream);
+		return const_cast<CopyData*>(this)->Serialize(stream);
+	}
+#pragma endregion
+};

--- a/src/Ext/EffectType/Effect/CopyEffect.cpp
+++ b/src/Ext/EffectType/Effect/CopyEffect.cpp
@@ -1,0 +1,238 @@
+﻿#include "CopyEffect.h"
+
+#include <algorithm>
+
+#include "CopyShared.h" // CopyAEInfo / CopyCollectSnapshot / CopyClueAllowed / CopyCollectSources / CopyResolveSource
+
+// 发放组：一个粘贴对象 + 它要收到的清单项（按 list 索引）
+struct CopyDispatch
+{
+	TechnoClass* obj = nullptr;
+	std::vector<size_t> items;
+};
+
+void CopyEffect::OnStart()
+{
+	// AE 激活当帧立刻执行第 1 次（t=0 即第一次执行）
+	ExecuteOnce();
+	// 若还没到次数上限（或组件已被自己移除），启动周期等待下一轮
+	if (IsActive())
+	{
+		_cycleTimer.Start(GetDelayFrame());
+	}
+}
+
+void CopyEffect::OnUpdate()
+{
+	// Start 尚未发生（_started=false）或周期未到，不做任何事
+	if (!_started || _cycleTimer.Expired() == false)
+	{
+		return;
+	}
+	ExecuteOnce();
+	if (IsActive())
+	{
+		_cycleTimer.Start(GetDelayFrame()); // 周期推进：每 Delay 帧一次
+	}
+}
+
+void CopyEffect::ExecuteOnce()
+{
+	AttachEffectScript* myAE = AE;        // 本效果器所在 AE
+	TechnoClass* host = pTechno;          // 宿主（EffectScript::pTechno，宿主非 Techno 时为 null）
+	if (!host)
+	{
+		return; // 宿主须是 Techno
+	}
+	TechnoClass* copySource = myAE->pSource; // CopyAE 的来源（Source 位 / 回退链 Source 位）
+
+	// Copy.From：观察谁身上的 AE（Target=宿主，默认；Source=CopyAE 来源）
+	// 观察源与 AttachTo（贴给谁）、AttachFrom（来源记谁）各自独立
+	TechnoClass* fromObject = Data->From == CopyFrom::Source ? copySource : host;
+	if (CopyIsDead(fromObject))
+	{
+		return; // 观察源无效：本次作废、不计次数
+	}
+	AttachEffect* fromAEM = nullptr;
+	if (!TryGetAEManager<TechnoExt>(fromObject, fromAEM))
+	{
+		return; // 观察源无 AE 管理器：本次作废（fromObject==host 时必然成功）
+	}
+
+	// ---- 1. 收集快照：观察源身上全部正在生效的 AE（收集完才操作，防遍历中增删）----
+	std::vector<CopyAEInfo> infos;
+	CopyCollectSnapshot(fromAEM, infos);
+
+	// ---- 2. Watch 过滤 -> 候选清单（Ignore 黑名单优先 -> Watch 白名单，空=全量）----
+	std::vector<CopyAEInfo> list;
+	for (const CopyAEInfo& info : infos)
+	{
+		if (CopyClueAllowed(Data->Watch, info))
+		{
+			list.push_back(info);
+		}
+	}
+
+	// ---- 3. DiscardOnInitialSourceDead：死源清单级移除（不回退）----
+	if (Data->DiscardOnInitialSourceDead)
+	{
+		// yes：来源单位已死的命中 AE 一律移除
+		auto it = std::remove_if(list.begin(), list.end(), [](const CopyAEInfo& info) {
+			return CopyIsDead(info.source);
+		});
+		list.erase(it, list.end());
+	}
+	// no：保留（是否贴由 AttachTo 判定；来源解析走回退链）
+
+	// 清单为空：本次无动作、不计次数
+	if (list.empty())
+	{
+		return;
+	}
+
+	// ---- 4. Cut：最终清单确定后立即移除观察源身上属于清单名字的源 AE----
+	// 跳过 Next 链；与 AttachTo 无关；执行在一切附加之前
+	if (Data->Cut && fromAEM)
+	{
+		std::vector<std::string> names;
+		for (const CopyAEInfo& info : list)
+		{
+			if (info.data.Copy.Enable)
+			{
+				continue; // 与观察过滤同规则：带 Copy 效果器的 AE 不参与 Cut
+			}
+			if (!CopyContains(names, info.name))
+			{
+				names.push_back(info.name);
+			}
+		}
+		fromAEM->DetachByName(names, true); // 现有基建：名字级移除，skipNext=true 跳过 Next 链
+	}
+
+	// ---- 5. 按 AttachTo 解析发放对象（目标死亡只影响是否贴）----
+	std::vector<CopyDispatch> dispatches;
+	bool targetOk = true;
+	switch (Data->AttachTo)
+	{
+	case CopyAttachTo::Source:
+		// 整份清单 -> CopyAE 来源
+		if (!CopyIsDead(copySource))
+		{
+			dispatches.push_back({ copySource, std::vector<size_t>{} });
+			for (size_t i = 0; i < list.size(); i++)
+			{
+				dispatches[0].items.push_back(i);
+			}
+		}
+		else
+		{
+			targetOk = false; // 粘贴对象死亡：本次作废
+		}
+		break;
+	case CopyAttachTo::Target:
+		// 整份清单 -> 宿主自己
+		dispatches.push_back({ host, std::vector<size_t>{} });
+		for (size_t i = 0; i < list.size(); i++)
+		{
+			dispatches[0].items.push_back(i);
+		}
+		break;
+	case CopyAttachTo::InitialSource:
+	{
+		// 广播：先出清单内各 AE 初始来源的去重清单（死源不发），每个来源都收整份清单
+		std::vector<TechnoClass*> sources;
+		CopyCollectSources(list, sources);
+		if (sources.empty())
+		{
+			targetOk = false;
+			break;
+		}
+		std::vector<size_t> all;
+		for (size_t i = 0; i < list.size(); i++)
+		{
+			all.push_back(i);
+		}
+		for (TechnoClass* src : sources)
+		{
+			dispatches.push_back({ src, all });
+		}
+		break;
+	}
+	case CopyAttachTo::Return:
+		// 逐条返还：每条命中 AE 只发回它自己的初始来源
+		for (size_t i = 0; i < list.size(); i++)
+		{
+			TechnoClass* src = list[i].source;
+			if (CopyIsDead(src))
+			{
+				continue; // 返还对象已死：该条不贴
+			}
+			CopyDispatch* found = nullptr;
+			for (CopyDispatch& d : dispatches)
+			{
+				if (d.obj == src)
+				{
+					found = &d;
+					break;
+				}
+			}
+			if (!found)
+			{
+				dispatches.push_back({ src, std::vector<size_t>{} });
+				found = &dispatches.back();
+			}
+			found->items.push_back(i);
+		}
+		if (dispatches.empty())
+		{
+			targetOk = false; // 清单内没有任何一条的来源存活：本次作废
+		}
+		break;
+	}
+
+	// ---- 6. 逐对象逐条标准附加（来源=AttachFrom 独立解析；发放过滤=基类 FilterData）----
+	bool hasAttached = false;
+	if (targetOk)
+	{
+		for (const CopyDispatch& d : dispatches)
+		{
+			// AffectTypes/NotAffectTypes（基类 FilterData 字段）：发放对象类型检查——
+			// 只有名单内的对象才允许被贴（直接复用现有 CanAffectType(TechnoClass*)）
+			if (!Data->CanAffectType(d.obj))
+			{
+				continue; // 该对象不在类型名单内：不贴给它
+			}
+			AttachEffect* targetAEM = nullptr;
+			if (!TryGetAEManager<TechnoExt>(d.obj, targetAEM))
+			{
+				continue; // 对象无 AE 管理器（极端）：跳过该对象
+			}
+			// OnlyAffectMarks/NotAffectMarks（基类 FilterData 字段）：发放对象标记检查
+			if (!Data->OnMark(targetAEM->GetMarks()))
+			{
+				continue; // 对象标记未过名单：不贴给它
+			}
+			for (size_t i : d.items)
+			{
+				const CopyAEInfo& info = list[i];
+				TechnoClass* pSource = CopyResolveSource(Data->AttachFrom, info.source, copySource, host);
+				// 直接调用现有基建 AttachEffect::Attach：Enable/铁幕/排斥/金钱/叠加/分组/
+				// Delay/Stack 等全套校验都在内部，Copy 不做任何预检、不干预结果
+				targetAEM->Attach(info.data, pSource, nullptr, CoordStruct::Empty, -1, false);
+				hasAttached = true;
+			}
+		}
+	}
+
+	// ---- 7. 成功判定与次数管理：有实际附加才算本次成功 ----
+	if (!hasAttached)
+	{
+		return; // 本次作废、不计次数
+	}
+	_count++;
+	if (Data->TriggeredTimes > 0 && _count >= Data->TriggeredTimes)
+	{
+		Deactivate();    // 组件公开方法：标记停用
+		AE->TimeToDie(); // AttachEffectScript 公开方法：停寿命计时，由 AE 管理器帧检查统一移除
+	}
+}

--- a/src/Ext/EffectType/Effect/CopyEffect.h
+++ b/src/Ext/EffectType/Effect/CopyEffect.h
@@ -1,0 +1,71 @@
+﻿#pragma once
+// ============================================================================
+// CopyEffect — 效果器脚本层（纯主线程）
+//
+// 生命周期：AE 激活（_started=true）当帧 OnStart 立刻执行第 1 次；
+// 之后每 Copy.Delay 帧执行 1 次（Delay<=0 按 1 帧）；累计 Copy.TriggeredTimes
+// 次成功后整条 CopyAE 移除（Deactivate + AE->TimeToDie）。
+// 单次执行主体 ExecuteOnce：收集观察源快照 -> Watch 过滤 -> Discard -> (Cut)
+// -> AttachTo 解析发放 -> 逐条标准附加。附加动作直接调用现有 Attach 基建。
+// ============================================================================
+
+#include <string>
+#include <vector>
+
+#include <GeneralDefinitions.h> // CDTimerClass（YRpp/Timer.h）
+
+#include "../EffectScript.h"
+#include "CopyData.h"
+
+/// @brief 效果器：观察指定单位身上的 AE，把命中观察名单的 AE 贴到选定目标
+class CopyEffect : public EffectScript
+{
+public:
+	EFFECT_SCRIPT(Copy);
+
+	virtual void Clean() override
+	{
+		EffectScript::Clean();
+
+		_count = 0;
+		_cycleTimer = {};
+	}
+
+	virtual void OnStart() override;
+	virtual void OnUpdate() override;
+
+#pragma region Save/Load
+	template <typename T>
+	bool Serialize(T& stream) {
+		return stream
+			.Process(this->_count)
+			.Process(this->_cycleTimer)
+			.Success();
+	};
+
+	virtual bool Load(ExStreamReader& stream, bool registerForChange) override
+	{
+		EffectScript::Load(stream, registerForChange);
+		return this->Serialize(stream);
+	}
+	virtual bool Save(ExStreamWriter& stream) const override
+	{
+		EffectScript::Save(stream);
+		return const_cast<CopyEffect*>(this)->Serialize(stream);
+	}
+#pragma endregion
+private:
+
+	/// @brief 单次执行主体。成功 = 有实际附加，计入 _count
+	void ExecuteOnce();
+
+	/// @brief 周期帧数：Delay>0 取 Delay，否则按 1 帧
+	/// 不能声明 const：Data getter（EFFECT_SCRIPT 生成）是非 const 方法
+	int GetDelayFrame()
+	{
+		return Data->Delay > 0 ? Data->Delay : 1;
+	}
+
+	int _count = 0;          // 已成功执行次数（成功=清单非空且至少一个有效发放对象）
+	CDTimerClass _cycleTimer{}; // 周期计时（第一次由 OnStart 启动）
+};

--- a/src/Ext/EffectType/Effect/CopyShared.h
+++ b/src/Ext/EffectType/Effect/CopyShared.h
@@ -1,0 +1,142 @@
+﻿#pragma once
+// ============================================================================
+// CopyShared — Copy 与 Trace 共用的执行工具（同源族）
+//
+// 两个效果器共享：候选 AE 快照结构、快照收集、线索过滤判定、来源去重、死亡回退解析。
+// 观察名单语义（Watch/Ignore）与附加分发（AttachTo/AttachFrom）的差异在各自效果器内处理，
+// 本文件只放两边写法完全一致的部分。
+//
+// 本头只被两个效果器的 .h/.cpp 引用；CopyData.h / TraceData.h（会被
+// AttachEffectData.h 统一收集）不引用本头，避免与 AttachEffectData.h 形成包含环。
+// ============================================================================
+
+#include <string>
+#include <vector>
+#include <algorithm>
+
+#include <GeneralStructures.h>
+
+#include <Ext/Helper/Status.h>  // IsDeadOrInvisible
+#include <Ext/Helper/Scripts.h> // TryGetAEManager
+
+#include "CopyData.h"
+#include "../EffectScript.h"    // AttachEffectData / AttachEffectScript（快照需要完整类型）
+
+// 候选 AE 快照：完整数据 + 来源 + 名字 + 自带标记
+struct CopyAEInfo
+{
+	AttachEffectData data;
+	TechnoClass* source = nullptr;
+	std::string name;
+	std::vector<std::string> marks;
+};
+
+static inline bool CopyContains(const std::vector<std::string>& list, const std::string& key)
+{
+	return std::find(list.begin(), list.end(), key) != list.end();
+}
+
+static inline bool CopyIsDead(TechnoClass* p)
+{
+	return !p || IsDeadOrInvisible(p);
+}
+
+// 收集快照：对象 AE 管理器上全部正在生效的 AE（ForeachChild 只回调已激活组件；
+// 快照收集完才允许后续增删操作，防遍历中增删）
+static inline bool CopyCollectSnapshot(AttachEffect* aem, std::vector<CopyAEInfo>& out)
+{
+	if (!aem)
+	{
+		return false;
+	}
+	aem->ForeachChild([&](Component* c) {
+		AttachEffectScript* ae = dynamic_cast<AttachEffectScript*>(c);
+		if (!ae || !ae->IsAlive())
+		{
+			return; // 只收正在生效的
+		}
+		std::vector<std::string> marks;
+		ae->GetMarks(marks); // AttachEffectScript::GetMarks（单条 AE 自带标记）
+		out.push_back({ ae->AEData, ae->pSource, ae->AEData.Name, marks });
+	});
+	return true;
+}
+
+// 线索过滤判定：这条 AE 能否当观察线索
+// 剔除带 Copy 效果器的 AE（防嵌套）-> Ignore 黑名单优先 -> Watch 白名单（空=全量）。
+static inline bool CopyClueAllowed(const CopyWatchConfig& cfg, const CopyAEInfo& info)
+{
+	if (info.data.Copy.Enable)
+	{
+		return false; // 剔除带 Copy 效果器的 AE，防嵌套
+	}
+	if (!cfg.IgnoreTypes.empty() && CopyContains(cfg.IgnoreTypes, info.name))
+	{
+		return false; // 黑名单优先（AE 名）
+	}
+	if (!cfg.IgnoreMarks.empty() && CheckOnMarks(cfg.IgnoreMarks, info.marks))
+	{
+		return false; // 黑名单优先（自带标记）
+	}
+	if (!cfg.Watch.empty() && !CopyContains(cfg.Watch, info.name))
+	{
+		return false; // 白名单（AE 名）
+	}
+	if (!cfg.WatchMarks.empty() && !CheckOnMarks(cfg.WatchMarks, info.marks))
+	{
+		return false; // 白名单（自带标记）
+	}
+	return true;
+}
+
+// 从一份 AE 清单收集各 AE 初始来源的去重存活列表；死源剔除——死人当不了目标也当不了来源
+static inline void CopyCollectSources(const std::vector<CopyAEInfo>& items, std::vector<TechnoClass*>& out)
+{
+	for (const CopyAEInfo& info : items)
+	{
+		if (CopyIsDead(info.source))
+		{
+			continue;
+		}
+		if (std::find(out.begin(), out.end(), info.source) == out.end())
+		{
+			out.push_back(info.source);
+		}
+	}
+}
+
+// AttachFrom 来源解析 + 死亡回退（只决定"来源记谁"，与贴判定无关）：
+//   Source        死 -> Target 直退（不回退到 InitialSource）
+//   InitialSource 死 -> Source -> 再死 -> Target
+//   Target        宿主恒活，无回退
+static inline TechnoClass* CopyResolveSource(
+	CopyAttachFrom mode, TechnoClass* initialSource, TechnoClass* copySource, TechnoClass* host)
+{
+	TechnoClass* s = nullptr;
+	switch (mode)
+	{
+	case CopyAttachFrom::Source:
+		s = copySource;
+		if (CopyIsDead(s))
+		{
+			s = host;
+		}
+		break;
+	case CopyAttachFrom::Target:
+		s = host; // 宿主恒活
+		break;
+	case CopyAttachFrom::InitialSource:
+	default:
+		s = initialSource;
+		if (CopyIsDead(s))
+		{
+			s = copySource;
+		}
+		if (CopyIsDead(s))
+		{
+			s = host;
+		}
+		break;
+	}
+	return s;
+}

--- a/src/Ext/EffectType/Effect/TraceData.h
+++ b/src/Ext/EffectType/Effect/TraceData.h
@@ -1,0 +1,128 @@
+﻿#pragma once
+// ============================================================================
+// TraceData — Trace 数据层（Copy 同源族）
+//
+// 与 Copy 共用同一套观察/分发机制，差异仅两处：
+//   附加内容 = 本效果器自己的固定名单 AttachEffects（整串按名附加，Copy 附加观察命中的 AE）
+//   无 Cut / 无 AttachTo=Return（不是搬移命中 AE，没有可剪之物与可返对象）
+// 其余标签（From / Watch 名单组 / AttachTo 前三值 / AttachFrom / Discard /
+// Delay / TriggeredTimes / 发放过滤）与 Copy 完全一致，默认值对齐。
+// 前缀 Trace.；机制解耦规则见 CopyData.h 头注释。
+// ============================================================================
+
+#include <string>
+#include <vector>
+
+#include <GeneralStructures.h>
+
+#include <Common/INI/INIConfig.h>
+
+#include <Ext/EffectType/Effect/EffectData.h>
+#include <Ext/Helper/StringEx.h> // ClearIfGetNone
+
+#include "CopyData.h" // 取值枚举 / CopyWatchConfig / CopyParseAttachTo
+
+class TraceData : public EffectData
+{
+public:
+	EFFECT_DATA(Trace);
+
+	// ---- 观察与分发（前缀 Trace.*，与 Copy 同构）----
+	CopyFrom From = CopyFrom::Target;                       // INI: Trace.From（观察谁身上的 AE）
+	CopyWatchConfig Watch{};                                // INI: Trace.Watch / WatchMarks / IgnoreTypes / IgnoreMarks（观察名单组）
+	CopyAttachTo AttachTo = CopyAttachTo::Source;           // INI: Trace.AttachTo（贴给谁，限 Source/Target/InitialSource，无 Return）
+	CopyAttachFrom AttachFrom = CopyAttachFrom::InitialSource; // INI: Trace.AttachFrom（来源记谁）
+	bool DiscardOnInitialSourceDead = false;                // INI: Trace.DiscardOnInitialSourceDead（名单单位死亡：丢弃该轮 / 走完整回退）
+	std::vector<std::string> AttachEffects{};               // INI: Trace.AttachEffects（按名附加名单，空=执行时无动作）
+	int Delay = 0;                                          // INI: Trace.Delay（执行间隔帧，<=0 按 1 帧）
+
+	// ---- 移除（可独立使用，不要求 AttachEffects；执行在附加前）----
+	bool RemoveEffectsSkipNext = false;                     // INI: Trace.RemoveEffectsSkipNext（移除时是否跳过 Next 链，对齐 AmmoTrigger 先例）
+	std::vector<std::string> RemoveEffectsTarget{};         // INI: Trace.RemoveEffectsTarget（从宿主身上按名移除）
+	std::vector<std::string> RemoveEffectsTargetMarks{};    // INI: Trace.RemoveEffectsTargetMarks（宿主身上按标记移除）
+	std::vector<std::string> RemoveEffectsSource{};         // INI: Trace.RemoveEffectsSource（从挂本 AE 的单位身上按名移除）
+	std::vector<std::string> RemoveEffectsSourceMarks{};    // INI: Trace.RemoveEffectsSourceMarks（挂本 AE 单位身上按标记移除）
+	std::vector<std::string> RemoveEffectsInitialSource{};  // INI: Trace.RemoveEffectsInitialSource（从追溯出的各来源单位身上按名移除）
+	std::vector<std::string> RemoveEffectsInitialSourceMarks{}; // INI: Trace.RemoveEffectsInitialSourceMarks（各来源单位身上按标记移除）
+
+	TraceData() : EffectData()
+	{
+		// TriggeredTimes（基类键 Trace.TriggeredTimes）= 总执行次数，默认 1（激活执行 1 次即耗尽）
+		this->TriggeredTimes = 1;
+	}
+
+	virtual void Read(INIBufferReader* reader) override
+	{
+		Read(reader, "Trace.");
+	}
+
+	virtual void Read(INIBufferReader* reader, std::string title) override
+	{
+		// 直接复用基类读取（Trace.Enable / TriggeredTimes / AffectTypes 等发放过滤键）
+		EffectData::Read(reader, title);
+
+		From = reader->Get(title + "From", From);
+		Watch.Read(reader, title);
+		std::string raw;
+		if (reader->TryGet(title + "AttachTo", raw))
+		{
+			CopyParseAttachTo(raw.c_str(), false, &this->AttachTo); // 限三值：Return 不接受
+		}
+		AttachFrom = reader->Get(title + "AttachFrom", AttachFrom);
+		DiscardOnInitialSourceDead = reader->Get(title + "DiscardOnInitialSourceDead", DiscardOnInitialSourceDead);
+		AttachEffects = reader->GetList(title + "AttachEffects", AttachEffects);
+		ClearIfGetNone(AttachEffects);
+		Delay = reader->Get(title + "Delay", Delay);
+
+		RemoveEffectsSkipNext = reader->Get(title + "RemoveEffectsSkipNext", RemoveEffectsSkipNext);
+		RemoveEffectsTarget = reader->GetList(title + "RemoveEffectsTarget", RemoveEffectsTarget);
+		ClearIfGetNone(RemoveEffectsTarget);
+		RemoveEffectsTargetMarks = reader->GetList(title + "RemoveEffectsTargetMarks", RemoveEffectsTargetMarks);
+		ClearIfGetNone(RemoveEffectsTargetMarks);
+		RemoveEffectsSource = reader->GetList(title + "RemoveEffectsSource", RemoveEffectsSource);
+		ClearIfGetNone(RemoveEffectsSource);
+		RemoveEffectsSourceMarks = reader->GetList(title + "RemoveEffectsSourceMarks", RemoveEffectsSourceMarks);
+		ClearIfGetNone(RemoveEffectsSourceMarks);
+		RemoveEffectsInitialSource = reader->GetList(title + "RemoveEffectsInitialSource", RemoveEffectsInitialSource);
+		ClearIfGetNone(RemoveEffectsInitialSource);
+		RemoveEffectsInitialSourceMarks = reader->GetList(title + "RemoveEffectsInitialSourceMarks", RemoveEffectsInitialSourceMarks);
+		ClearIfGetNone(RemoveEffectsInitialSourceMarks);
+	}
+
+#pragma region save/load
+	template <typename T>
+	bool Serialize(T& stream)
+	{
+		return stream
+			.Process(this->From)
+			.Process(this->Watch.Watch)
+			.Process(this->Watch.WatchMarks)
+			.Process(this->Watch.IgnoreTypes)
+			.Process(this->Watch.IgnoreMarks)
+			.Process(this->AttachTo)
+			.Process(this->AttachFrom)
+			.Process(this->DiscardOnInitialSourceDead)
+			.Process(this->AttachEffects)
+			.Process(this->Delay)
+			.Process(this->RemoveEffectsSkipNext)
+			.Process(this->RemoveEffectsTarget)
+			.Process(this->RemoveEffectsTargetMarks)
+			.Process(this->RemoveEffectsSource)
+			.Process(this->RemoveEffectsSourceMarks)
+			.Process(this->RemoveEffectsInitialSource)
+			.Process(this->RemoveEffectsInitialSourceMarks)
+			.Success();
+	};
+
+	virtual bool Load(ExStreamReader& stream, bool registerForChange) override
+	{
+		EffectData::Load(stream, registerForChange);
+		return this->Serialize(stream);
+	}
+	virtual bool Save(ExStreamWriter& stream) const override
+	{
+		EffectData::Save(stream);
+		return const_cast<TraceData*>(this)->Serialize(stream);
+	}
+#pragma endregion
+};

--- a/src/Ext/EffectType/Effect/TraceEffect.cpp
+++ b/src/Ext/EffectType/Effect/TraceEffect.cpp
@@ -1,0 +1,243 @@
+﻿#include "TraceEffect.h"
+
+#include "CopyShared.h" // CopyCollectSnapshot / CopyClueAllowed / CopyCollectSources / CopyResolveSource
+
+// 从指定单位身上按名/按标记移除 AE（调用现成基建 DetachByName / DetachByMarks，
+// skipNext 由配置决定是否跳过被移除 AE 的 Next 链）
+static void TraceRemoveFrom(TechnoClass* obj,
+	const std::vector<std::string>& names, const std::vector<std::string>& marks, bool skipNext)
+{
+	if (!obj || (names.empty() && marks.empty()))
+	{
+		return;
+	}
+	AttachEffect* aem = nullptr;
+	if (!TryGetAEManager<TechnoExt>(obj, aem))
+	{
+		return; // 该单位无 AE 管理器（极端/已死亡）：无处可删
+	}
+	if (!names.empty())
+	{
+		aem->DetachByName(names, skipNext);
+	}
+	if (!marks.empty())
+	{
+		aem->DetachByMarks(marks, skipNext);
+	}
+}
+
+void TraceEffect::OnStart()
+{
+	// AE 激活当帧立刻执行第 1 次（t=0 即第一次执行）
+	ExecuteOnce();
+	// 若还没到次数上限（或组件已被自己移除），启动周期等待下一轮
+	if (IsActive())
+	{
+		_cycleTimer.Start(GetDelayFrame());
+	}
+}
+
+void TraceEffect::OnUpdate()
+{
+	// Start 尚未发生（_started=false）或周期未到，不做任何事
+	if (!_started || _cycleTimer.Expired() == false)
+	{
+		return;
+	}
+	ExecuteOnce();
+	if (IsActive())
+	{
+		_cycleTimer.Start(GetDelayFrame()); // 周期推进：每 Delay 帧一次
+	}
+}
+
+void TraceEffect::ExecuteOnce()
+{
+	AttachEffectScript* myAE = AE;        // 本效果器所在 AE
+	TechnoClass* host = pTechno;          // 宿主（EffectScript::pTechno，宿主非 Techno 时为 null）
+	if (!host)
+	{
+		return; // 宿主须是 Techno
+	}
+	TechnoClass* copySource = myAE->pSource; // 挂本 AE 的单位（Source 位 / 回退链 Source 位）
+
+	// 有何事可做：附加（AttachEffects 非空）或任一位置的移除名单非空
+	bool hasAttach = !Data->AttachEffects.empty();
+	bool hasRemoveTarget = !Data->RemoveEffectsTarget.empty() || !Data->RemoveEffectsTargetMarks.empty();
+	bool hasRemoveSource = !Data->RemoveEffectsSource.empty() || !Data->RemoveEffectsSourceMarks.empty();
+	bool hasRemoveInit = !Data->RemoveEffectsInitialSource.empty()
+		|| !Data->RemoveEffectsInitialSourceMarks.empty();
+	if (!hasAttach && !hasRemoveTarget && !hasRemoveSource && !hasRemoveInit)
+	{
+		return; // 无事可做：本次无动作、不计次数
+	}
+
+	// ---- 观察快照：附加与 InitialSource 移除都需要追溯来源（From 定观察源）----
+	bool needObserve = hasAttach || hasRemoveInit;
+	std::vector<CopyAEInfo> infos;
+	bool observed = false;
+	if (needObserve)
+	{
+		TechnoClass* fromObject = Data->From == CopyFrom::Source ? copySource : host;
+		if (!CopyIsDead(fromObject))
+		{
+			AttachEffect* fromAEM = nullptr;
+			if (TryGetAEManager<TechnoExt>(fromObject, fromAEM))
+			{
+				CopyCollectSnapshot(fromAEM, infos);
+				observed = true;
+			}
+		}
+	}
+	// 观察不可用（观察源死亡/无管理器）：依赖追溯的动作做不了
+	if (needObserve && !observed)
+	{
+		if (!hasRemoveTarget && !hasRemoveSource)
+		{
+			return; // 只剩依赖观察的动作，全部不可执行
+		}
+		hasAttach = false;   // 附加需要线索：观察失败则不附加
+		hasRemoveInit = false; // InitialSource 移除需要来源名单：观察失败则不做
+	}
+
+	// ---- 线索过滤与来源名单（观察成功才可用；附加与 InitialSource 移除共用一份）----
+	std::vector<CopyAEInfo> clues;
+	std::vector<TechnoClass*> sources;
+	if (observed)
+	{
+		for (const CopyAEInfo& info : infos)
+		{
+			if (CopyClueAllowed(Data->Watch, info))
+			{
+				clues.push_back(info);
+			}
+		}
+		bool needList = hasAttach
+			&& (Data->AttachTo == CopyAttachTo::InitialSource
+				|| Data->AttachFrom == CopyAttachFrom::InitialSource);
+		if (hasRemoveInit || needList)
+		{
+			CopyCollectSources(clues, sources);
+		}
+	}
+
+	// ---- 移除步骤（先于附加；三位置各自独立可同时执行）----
+	if (hasRemoveTarget && !CopyIsDead(host))
+	{
+		TraceRemoveFrom(host, Data->RemoveEffectsTarget, Data->RemoveEffectsTargetMarks, Data->RemoveEffectsSkipNext);
+	}
+	if (hasRemoveSource && !CopyIsDead(copySource))
+	{
+		TraceRemoveFrom(copySource, Data->RemoveEffectsSource, Data->RemoveEffectsSourceMarks, Data->RemoveEffectsSkipNext);
+	}
+	bool hasRemoved = hasRemoveTarget || hasRemoveSource
+		|| (hasRemoveInit && !sources.empty());
+	if (hasRemoveInit && !sources.empty())
+	{
+		for (TechnoClass* s : sources)
+		{
+			if (CopyIsDead(s))
+			{
+				continue;
+			}
+			TraceRemoveFrom(s, Data->RemoveEffectsInitialSource, Data->RemoveEffectsInitialSourceMarks, Data->RemoveEffectsSkipNext);
+		}
+	}
+
+	// ---- 附加步骤（目标 × 来源份额全组合）----
+	bool hasAttached = false;
+	if (hasAttach && observed)
+	{
+		bool needList = Data->AttachTo == CopyAttachTo::InitialSource
+			|| Data->AttachFrom == CopyAttachFrom::InitialSource;
+		if (needList && sources.empty())
+		{
+			hasAttach = false; // 无来源可发：附加不做
+		}
+	}
+	if (hasAttach && observed)
+	{
+		bool needList = Data->AttachTo == CopyAttachTo::InitialSource
+			|| Data->AttachFrom == CopyAttachFrom::InitialSource;
+
+		// 目标集合：AttachTo 定贴给谁（Source=挂本 AE 的单位 / Target=宿主 / InitialSource=来源名单）
+		std::vector<TechnoClass*> targets;
+		switch (Data->AttachTo)
+		{
+		case CopyAttachTo::Source:
+			if (!CopyIsDead(copySource))
+			{
+				targets.push_back(copySource);
+			}
+			break;
+		case CopyAttachTo::Target:
+			targets.push_back(host); // 宿主恒活
+			break;
+		case CopyAttachTo::InitialSource:
+		default:
+			targets = sources; // 名单收集时已剔死源
+			break;
+		}
+
+		// 来源份额集合：AttachFrom=InitialSource 时每个名单单位一个份额，否则固定一个
+		bool perSource = Data->AttachFrom == CopyAttachFrom::InitialSource;
+		std::vector<TechnoClass*> froms;
+		if (perSource)
+		{
+			froms = sources;
+		}
+		else
+		{
+			froms.push_back(CopyResolveSource(Data->AttachFrom, nullptr, copySource, host));
+		}
+
+		for (TechnoClass* obj : targets)
+		{
+			// 目标死亡：该目标的全部份额不贴
+			if (CopyIsDead(obj))
+			{
+				continue;
+			}
+			// 发放对象过滤（基类 FilterData，读 Trace.* 键）
+			if (!Data->CanAffectType(obj))
+			{
+				continue;
+			}
+			AttachEffect* targetAEM = nullptr;
+			if (!TryGetAEManager<TechnoExt>(obj, targetAEM))
+			{
+				continue;
+			}
+			if (!Data->OnMark(targetAEM->GetMarks()))
+			{
+				continue;
+			}
+			for (TechnoClass* s : froms)
+			{
+				// Discard=yes 且该来源份额单位（名单单位）已死：该份额丢弃，走不到回退
+				if (perSource && Data->DiscardOnInitialSourceDead && CopyIsDead(s))
+				{
+					continue;
+				}
+				TechnoClass* attachFrom = perSource
+					? CopyResolveSource(CopyAttachFrom::InitialSource, s, copySource, host)
+					: s; // 固定来源已在份额集合里解析好
+				// 整串按名附加（现有基建 AttachEffect::Attach 按名列表重载，一次带全名单）
+				targetAEM->Attach(Data->AttachEffects, {}, false, attachFrom, nullptr);
+				hasAttached = true;
+			}
+		}
+	}
+
+	// ---- 成功判定与次数管理：移除或附加任一发生即算本次成功 ----
+	if (!hasAttached && !hasRemoved)
+	{
+		return; // 本次无动作、不计次数
+	}
+	_count++;
+	if (Data->TriggeredTimes > 0 && _count >= Data->TriggeredTimes)
+	{
+		Deactivate();    // 组件公开方法：标记停用
+		AE->TimeToDie(); // AttachEffectScript 公开方法：停寿命计时，由 AE 管理器帧检查统一移除
+	}
+}

--- a/src/Ext/EffectType/Effect/TraceEffect.h
+++ b/src/Ext/EffectType/Effect/TraceEffect.h
@@ -1,0 +1,71 @@
+﻿#pragma once
+// ============================================================================
+// TraceEffect — 效果器脚本层（Copy 同源族）
+//
+// 生命周期与 Copy 一致：AE 激活当帧 OnStart 执行第 1 次 -> 每 Trace.Delay
+// 帧一次（<=0 按 1 帧）-> 累计 Trace.TriggeredTimes 次成功后整条 AE 移除。
+// 单次执行主体 ExecuteOnce：收集观察源快照 -> Watch 过滤得线索 -> 需要来源名单时
+// 收线索来源去重 -> 逐轮（目标 + 来源 + 发放过滤）整串按名附加 AttachEffects。
+// 观察只提供"分发给谁 / 来源记谁"的角色，附加内容始终是 INI 固定名单。
+// ============================================================================
+
+#include <string>
+#include <vector>
+
+#include <GeneralDefinitions.h> // CDTimerClass（YRpp/Timer.h）
+
+#include "../EffectScript.h"
+#include "TraceData.h"
+
+/// @brief 效果器：观察指定单位身上的 AE，把固定名单按名附加到选定目标
+class TraceEffect : public EffectScript
+{
+public:
+	EFFECT_SCRIPT(Trace);
+
+	virtual void Clean() override
+	{
+		EffectScript::Clean();
+
+		_count = 0;
+		_cycleTimer = {};
+	}
+
+	virtual void OnStart() override;
+	virtual void OnUpdate() override;
+
+#pragma region Save/Load
+	template <typename T>
+	bool Serialize(T& stream) {
+		return stream
+			.Process(this->_count)
+			.Process(this->_cycleTimer)
+			.Success();
+	};
+
+	virtual bool Load(ExStreamReader& stream, bool registerForChange) override
+	{
+		EffectScript::Load(stream, registerForChange);
+		return this->Serialize(stream);
+	}
+	virtual bool Save(ExStreamWriter& stream) const override
+	{
+		EffectScript::Save(stream);
+		return const_cast<TraceEffect*>(this)->Serialize(stream);
+	}
+#pragma endregion
+private:
+
+	/// @brief 单次执行主体。成功 = 有实际附加，计入 _count
+	void ExecuteOnce();
+
+	/// @brief 周期帧数：Delay>0 取 Delay，否则按 1 帧
+	/// 不能声明 const：Data getter（EFFECT_SCRIPT 生成）是非 const 方法
+	int GetDelayFrame()
+	{
+		return Data->Delay > 0 ? Data->Delay : 1;
+	}
+
+	int _count = 0;          // 已成功执行次数（成功=至少一个有效轮次完成附加）
+	CDTimerClass _cycleTimer{}; // 周期计时（第一次由 OnStart 启动）
+};

--- a/附件包/Kratos食用说明书.ini
+++ b/附件包/Kratos食用说明书.ini
@@ -1524,6 +1524,59 @@ Vector.CircleSpeed=0 ;圆周运动速率
 Vector.CircleAnglePerStep=0 ;角速度。和速率二选一，都写时取角速度优先
 Vector.CircleOrigin=0,0,0 ;圆心偏移量，和OriginFLH叠加
 Vector.NormalVector=0,0,0 ;圆心法线向量，决定圆面倾斜
+;模块：复制器。复制指定对象身上的全体AE到指定目标。实质上是从附着单位身上读取AE列表后直接贴新的，跟被弹头打了或者吃到广播一样，能不能贴上走现成过滤路径。不会继承Duration。复制器不会被复制。
+Copy.Enable=no;效果器总开关，yes 才生效
+Copy.From=Target;复制谁身上的 AE：Target=本AE所在单位（默认）/ Source=给本AE所在单位挂本 AE 的单位
+Copy.Watch=none;复制AE白名单，不写就复制所有AE
+Copy.WatchMarks=none;复制白名单Mark，不写就复制所有AE
+Copy.IgnoreTypes=none;检查AE黑名单，优先于Watch
+Copy.IgnoreMarks=none;检查Mark黑名单，优先于WatchMarks
+Copy.AttachTo=Source;素材贴给谁：Source=挂本 AE 的单位（默认）/ Target=本AE所在单位自己 / InitialSource=按复制来源分发（每来源收整个AE列表）/ Return=每个来源收到自己发出去过的AE（反弹）
+Copy.AttachFrom=InitialSource;附加的来源记谁：InitialSource=各条记自己的来源（默认）/ Source=全记挂本 AE 的单位 / Target=全记本AE所在单位；带死亡回退（InitialSource 死→Source→本AE所在单位；Source 死→本AE所在单位）
+Copy.DiscardOnInitialSourceDead=no;素材来源已死时：no=保留并走来源回退链 / yes=该AE从清单丢弃
+Copy.Cut=no;剪切模式。强制不会触发Next；AttachTo=Target 时=先清后贴（重置）
+Copy.Delay=0;执行间隔帧（<=0 按 1 帧）；激活帧执行第 1 次
+Copy.TriggeredTimes=1;总执行次数，用尽后整条 AE 移除，默认一次
+Copy.AffectTypes=none;发放对象类型白名单（能贴给哪些单位类型），空=全放行
+Copy.NotAffectTypes=none;发放对象类型黑名单（优先）
+Copy.AffectBuilding=yes;发放对象过滤：是否允许贴给建筑
+Copy.AffectInfantry=yes;发放对象过滤：是否允许贴给步兵
+Copy.AffectUnit=yes;发放对象过滤：是否允许贴给车辆
+Copy.AffectAircraft=yes;发放对象过滤：是否允许贴给飞行器
+Copy.OnlyAffectMarks=none;发放对象标记白名单（目标身上汇总标记）
+Copy.NotAffectMarks=none;发放对象标记黑名单（优先）
+;追溯器，根据追踪的AE/Mark类型去追溯它们的来源，然后额外附着AE列表。类似于某种Stack的变体。机制和Copy共同，少量不同
+;同名AE身上存在多个来源的实例时，每有一个来源就给附着目标执行一次。
+;注意，追溯器的AttachFrom和AttachTo都为InitialSource时会产生乘法，产出平方数的AE个数
+;追溯器可以被互相追溯。建议Cumulative=no
+Trace.Enable=no;效果器总开关，yes 才生效
+Trace.AttachEffects=none;AE列表，空=执行无动作
+Trace.From=Target;检查谁身上的 AE：Target=本AE所在单位（默认）/ Source=给本AE所在单位挂本 AE 的单位
+Trace.Watch=none;检查AE白名单，命中当线索取来源；空=全量
+Trace.WatchMarks=none;检查Mark白名单；空=全量
+Trace.IgnoreTypes=none;检查AE黑名单，优先于 Watch
+Trace.IgnoreMarks=none;检查Mark黑名单，优先于 WatchMarks
+Trace.AttachTo=Source;名单贴给谁：Source=挂本 AE 的单位（默认）/ Target=本AE所在单位自己 / InitialSource=按线索来源逐单位分发（每个来源收到整串名单）；无 Return
+Trace.AttachFrom=InitialSource;附加的来源记谁：InitialSource=记各分发目标自己（默认）/ Source=全记挂本 AE 的单位 / Target=全记本AE所在单位；带死亡回退（同 Copy）
+;移除AE。InitialSource需要有Watch对象来追溯名单
+Trace.RemoveEffectsTarget=none;删追溯器附着单位身上的AE
+Trace.RemoveEffectsTargetMarks=none;按Mark删追溯器附着单位身上的AE
+Trace.RemoveEffectsSource=none;删追溯器来源身上的AE
+Trace.RemoveEffectsSourceMarks=none;按Mark删追溯器来源身上的AE
+Trace.RemoveEffectsInitialSource=none;获取Watch的AE的来源，去它们身上删AE
+Trace.RemoveEffectsInitialSourceMarks=none;获取Watch的AE的来源，去它们身上删按MarkAE
+Trace.RemoveEffectsSkipNext=no;删AE是否不触发Next
+Trace.DiscardOnInitialSourceDead=no;名单单位（来源位）已死时：no=该轮照贴并走完整来源回退 / yes=该轮丢弃
+Trace.Delay=1;执行间隔
+Trace.TriggeredTimes=1;总执行次数
+Trace.AffectTypes=none;发放对象类型白名单（能贴给哪些单位类型），空=全放行
+Trace.NotAffectTypes=none;发放对象类型黑名单（优先）
+Trace.AffectBuilding=yes;发放对象过滤：是否允许贴给建筑
+Trace.AffectInfantry=yes;发放对象过滤：是否允许贴给步兵
+Trace.AffectUnit=yes;发放对象过滤：是否允许贴给车辆
+Trace.AffectAircraft=yes;发放对象过滤：是否允许贴给飞行器
+Trace.OnlyAffectMarks=none;发放对象标记白名单（目标身上汇总标记）
+Trace.NotAffectMarks=none;发放对象标记黑名单（优先）
 ;====== 以下为【状态类型】模块，只允许生效一个，后赋予的覆盖并强制结束之前赋予的 ======
 ; 模块：彩弹, 状态类型 —— AE生效期间，对附着对象和其所持有的替身进行染色，由于游戏自身问题，透明状态无法染色，对于vxl抛射体无法染色，只能调光
 Paintball.Color=255,255,255 ;RGB888，需要大于128才会显色，比如：金色=（180,170,0）


### PR DESCRIPTION

;模块：复制器。复制指定对象身上的全体AE到指定目标。实质上是从附着单位身上读取AE列表后直接贴新的，跟被弹头打了或者吃到广播一样，能不能贴上走现成过滤路径。不会继承Duration。复制器不会被复制。
Copy.Enable=no;效果器总开关，yes 才生效
Copy.From=Target;复制谁身上的 AE：Target=本AE所在单位（默认）/ Source=给本AE所在单位挂本 AE 的单位
Copy.Watch=none;复制AE白名单，不写就复制所有AE
Copy.WatchMarks=none;复制白名单Mark，不写就复制所有AE
Copy.IgnoreTypes=none;检查AE黑名单，优先于Watch
Copy.IgnoreMarks=none;检查Mark黑名单，优先于WatchMarks
Copy.AttachTo=Source;素材贴给谁：Source=挂本 AE 的单位（默认）/ Target=本AE所在单位自己 / InitialSource=按复制来源分发（每来源收整个AE列表）/ Return=每个来源收到自己发出去过的AE（反弹）
Copy.AttachFrom=InitialSource;附加的来源记谁：InitialSource=各条记自己的来源（默认）/ Source=全记挂本 AE 的单位 / Target=全记本AE所在单位；带死亡回退（InitialSource 死→Source→本AE所在单位；Source 死→本AE所在单位）
Copy.DiscardOnInitialSourceDead=no;素材来源已死时：no=保留并走来源回退链 / yes=该AE从清单丢弃
Copy.Cut=no;剪切模式。强制不会触发Next；AttachTo=Target 时=先清后贴（重置）
Copy.Delay=0;执行间隔帧（<=0 按 1 帧）；激活帧执行第 1 次
Copy.TriggeredTimes=1;总执行次数，用尽后整条 AE 移除，默认一次
Copy.AffectTypes=none;发放对象类型白名单（能贴给哪些单位类型），空=全放行
Copy.NotAffectTypes=none;发放对象类型黑名单（优先）
Copy.AffectBuilding=yes;发放对象过滤：是否允许贴给建筑
Copy.AffectInfantry=yes;发放对象过滤：是否允许贴给步兵
Copy.AffectUnit=yes;发放对象过滤：是否允许贴给车辆
Copy.AffectAircraft=yes;发放对象过滤：是否允许贴给飞行器
Copy.OnlyAffectMarks=none;发放对象标记白名单（目标身上汇总标记）
Copy.NotAffectMarks=none;发放对象标记黑名单（优先）


;追溯器，根据追踪的AE/Mark类型去追溯它们的来源，然后额外附着AE列表。类似于某种Stack的变体。机制和Copy共同，少量不同
;同名AE身上存在多个来源的实例时，每有一个来源就给附着目标执行一次。
;注意，追溯器的AttachFrom和AttachTo都为InitialSource时会产生乘法，产出平方数的AE个数
;追溯器可以被互相追溯。建议Cumulative=no

Trace.Enable=no;效果器总开关，yes 才生效
Trace.AttachEffects=none;AE列表，空=执行无动作
Trace.From=Target;检查谁身上的 AE：Target=本AE所在单位（默认）/ Source=给本AE所在单位挂本 AE 的单位
Trace.Watch=none;检查AE白名单，命中当线索取来源；空=全量
Trace.WatchMarks=none;检查Mark白名单；空=全量
Trace.IgnoreTypes=none;检查AE黑名单，优先于 Watch
Trace.IgnoreMarks=none;检查Mark黑名单，优先于 WatchMarks
Trace.AttachTo=Source;名单贴给谁：Source=挂本 AE 的单位（默认）/ Target=本AE所在单位自己 / InitialSource=按线索来源逐单位分发（每个来源收到整串名单）；无 Return
Trace.AttachFrom=InitialSource;附加的来源记谁：InitialSource=记各分发目标自己（默认）/ Source=全记挂本 AE 的单位 / Target=全记本AE所在单位；带死亡回退（同 Copy）
;移除AE。InitialSource需要有Watch对象来追溯名单
Trace.RemoveEffectsTarget=none;删追溯器附着单位身上的AE
Trace.RemoveEffectsTargetMarks=none;按Mark删追溯器附着单位身上的AE
Trace.RemoveEffectsSource=none;删追溯器来源身上的AE
Trace.RemoveEffectsSourceMarks=none;按Mark删追溯器来源身上的AE
Trace.RemoveEffectsInitialSource=none;获取Watch的AE的来源，去它们身上删AE
Trace.RemoveEffectsInitialSourceMarks=none;获取Watch的AE的来源，去它们身上删按MarkAE
Trace.RemoveEffectsSkipNext=no;删AE是否不触发Next
Trace.DiscardOnInitialSourceDead=no;名单单位（来源位）已死时：no=该轮照贴并走完整来源回退 / yes=该轮丢弃
Trace.Delay=1;执行间隔
Trace.TriggeredTimes=1;总执行次数
Trace.AffectTypes=none;发放对象类型白名单（能贴给哪些单位类型），空=全放行
Trace.NotAffectTypes=none;发放对象类型黑名单（优先）
Trace.AffectBuilding=yes;发放对象过滤：是否允许贴给建筑
Trace.AffectInfantry=yes;发放对象过滤：是否允许贴给步兵
Trace.AffectUnit=yes;发放对象过滤：是否允许贴给车辆
Trace.AffectAircraft=yes;发放对象过滤：是否允许贴给飞行器
Trace.OnlyAffectMarks=none;发放对象标记白名单（目标身上汇总标记）
Trace.NotAffectMarks=none;发放对象标记黑名单（优先）
